### PR TITLE
fix: ensure all requests wait for authentication before execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marzban-sdk",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "license": "MIT",
   "description": "Fully typed and implementing all marzban methods",
   "private": false,
@@ -26,7 +26,24 @@
     "marzban vpn",
     "marzban vpn api",
     "marzban vpn api client",
-    "vpn"
+    "vpn",
+    "http-client",
+    "api-client",
+    "vpn",
+    "proxy",
+    "shadowsocks",
+    "v2ray",
+    "xray",
+    "trojan",
+    "wireguard",
+    "ssr",
+    "vmess",
+    "vless",
+    "hysteria",
+    "tuic",
+    "rest-api",
+    "http",
+    "networking"
   ],
   "dependencies": {
     "axios": "^1.7.9"

--- a/src/MarzbanSDK.ts
+++ b/src/MarzbanSDK.ts
@@ -20,6 +20,8 @@ export interface Config {
 export class MarzbanSDK {
   private client: AxiosInstance;
   private configuration: Configuration;
+  private authPromise: Promise<void> | null = null;
+
   admin: AdminApi;
   core: CoreApi;
   node: NodeApi;
@@ -39,11 +41,19 @@ export class MarzbanSDK {
     this.user = new UserApi(this.configuration, undefined, this.client);
     this.system = new SystemApi(this.configuration, undefined, this.client);
     this.default = new DefaultApi(this.configuration, undefined, this.client);
-    this.subscription = new SubscriptionApi(this.configuration, undefined, this.client);
-    this.userTemplate = new UserTemplateApi(this.configuration, undefined, this.client);
+    this.subscription = new SubscriptionApi(
+      this.configuration,
+      undefined,
+      this.client
+    );
+    this.userTemplate = new UserTemplateApi(
+      this.configuration,
+      undefined,
+      this.client
+    );
 
     this.setupInterceptors(config);
-    this.authenticate(config);
+    this.authPromise = this.authenticate(config);
   }
 
   private createConfiguration(config: Config): Configuration {
@@ -61,22 +71,30 @@ export class MarzbanSDK {
   }
 
   private async authenticate(config: Config): Promise<void> {
-    try {
-      const data = await this.admin.adminToken(
-        config.username,
-        config.password
-      );
-      if (data?.access_token) {
-        this.configuration.accessToken = data.access_token;
+    this.authPromise = new Promise(async (resolve, reject) => {
+      try {
+        const admin = new AdminApi(this.configuration);
+        const data = await admin.adminToken(config.username, config.password);
+        if (data?.access_token) {
+          this.configuration.accessToken = data.access_token;
+
+          resolve();
+        } else {
+          reject(new Error("Failed to retrieve access token"));
+        }
+      } catch (error) {
+        console.error("Authentication failed", error);
+        reject(error);
       }
-    } catch (error) {
-      console.error("Authentication failed", error);
-    }
+    });
+
+    return this.authPromise;
   }
 
   private setupInterceptors(config: Config): void {
     this.client.interceptors.request.use(
-      (requestConfig) => {
+      async (requestConfig) => {
+        await this.waitForAuth();
         const accessToken = this.configuration.accessToken;
         requestConfig.headers.authorization = accessToken
           ? `Bearer ${accessToken}`
@@ -92,18 +110,21 @@ export class MarzbanSDK {
     );
   }
 
+  private async waitForAuth(): Promise<void> {
+    if (this.authPromise) {
+      await this.authPromise;
+    }
+  }
+
   private async handleUnauthorizedError(error: any, config: Config) {
     const errorConfig = error?.config;
     if (error?.response?.status === 401 && !errorConfig?.sent) {
       errorConfig.sent = true;
       try {
-        const data = await this.admin.adminToken(
-          config.username,
-          config.password
-        );
-        if (data?.access_token) {
-          this.configuration.accessToken = data.access_token;
-          errorConfig.headers.authorization = `Bearer ${data.access_token}`;
+        await this.authenticate(config);
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+          errorConfig.headers.authorization = `Bearer ${accessToken}`;
           return axios(errorConfig);
         }
       } catch (err) {


### PR DESCRIPTION
- Added request blocking until authentication is completed (waitForAuth).
- Fixed the logic of this.auth Promise, which prevents duplicate authorization requests.
- It is guaranteed to wait for authenticate() to complete before sending requests.
- Improved 401 Unauthorized processing: re-authentication and re-request with a new token.