### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ilmar7786/marzban-sdk/security/code-scanning/3](https://github.com/Ilmar7786/marzban-sdk/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here (without changing functionality): set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI tasks (install/lint/test/build).  
Edit `.github/workflows/ci.yml` near the top-level keys, ideally after `on:` (or before `jobs:`), so all jobs inherit it unless overridden.

No imports, methods, or dependencies are needed—just YAML config changes in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
