### PR TITLE
fix(sdk): never retry POST, and fix retries that weren't running at all

### DIFF
--- a/apps/docs/content/docs/advanced/http-retry.mdx
+++ b/apps/docs/content/docs/advanced/http-retry.mdx
@@ -50,15 +50,19 @@ const sdk = await createMarzbanSDK({
 
 ## What gets retried
 
-`axios-retry` retries requests that fail due to:
+Only safe methods — **GET, HEAD, OPTIONS** — are retried, and only for:
 
-- **Network errors** (connection refused, DNS failure, etc.)
-- **Idempotent 5xx responses** (500, 502, 503, 504) for safe HTTP methods (GET, HEAD, OPTIONS)
+- Network errors (e.g. a dropped connection with no response)
+- **5xx** and **429** responses
 
-It does **not** retry:
+The method check always comes first: `POST`, `PUT`, `PATCH`, and `DELETE` are
+never retried, not even on a network error — re-sending a request whose
+outcome is unknown could duplicate a write (e.g. `restartCore`).
 
-- `4xx` client errors (except 429 if configured separately)
-- Non-idempotent methods (POST, PUT, PATCH, DELETE) on 5xx — to avoid duplicate writes
+The one exception is the login request, which is retried on network errors
+since re-issuing a token has no side effects.
+
+Other `4xx` responses are never retried.
 
 ## 401 re-auth retry
 

--- a/apps/docs/content/docs/configuration/config-options.mdx
+++ b/apps/docs/content/docs/configuration/config-options.mdx
@@ -107,6 +107,9 @@ When `retries > 0`, failed HTTP requests are retried with **exponential backoff*
 | 3 | 4 s |
 | … | … (capped at 30 s) |
 
+Only safe methods (GET, HEAD, OPTIONS) are retried — see
+[HTTP & Retry](/docs/advanced/http-retry) for the full method/status breakdown.
+
 WebSocket reconnections after `403 Forbidden` also use the same `retries` limit.
 
 Set `retries: 0` to disable automatic retries.

--- a/apps/docs/content/docs/resources/changelog.mdx
+++ b/apps/docs/content/docs/resources/changelog.mdx
@@ -3,6 +3,18 @@ title: Changelog
 description: MarzbanSDK release history, version compatibility, breaking changes, and migration notes — including the v3.0.0 async webhook and Web Crypto updates.
 ---
 
+## v3.2.0
+
+**Behavioral change:**
+
+- **HTTP retries now actually run.** A bug had retries on the authenticated
+  client (`instanceAxios`) silently never firing for any method or error —
+  `axios-retry` was reading the request config off an already-wrapped
+  `HttpError`, which has none. Fixed, and scoped deliberately: only `GET`,
+  `HEAD`, `OPTIONS`, and the login request are retried. `POST`, `PUT`,
+  `PATCH`, and `DELETE` are never retried, including on network errors — see
+  [HTTP & Retry](/docs/advanced/http-retry).
+
 ## v3.0.0
 
 **Breaking changes:**

--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -53,11 +53,16 @@ a one-off `httpsAgent` per call for any request made immediately after
 `removeUser`/`removeUserTolerantly`, so it can't draw the poisoned socket
 from the shared pool.
 
-**Open:** only worked around at the test level. Not something the SDK can
-reasonably detect and self-heal from (an `ECONNRESET` is indistinguishable
-from any other transient network failure). `axios-retry`'s default retries
-did not recover it in practice — worth understanding why, if this turns out
-to affect real deployments and not just this dev image.
+Only worked around at the test level — not something the SDK can reasonably
+detect and self-heal from (an `ECONNRESET` is indistinguishable from any
+other transient network failure).
+
+`axios-retry`'s default retries didn't recover it because they weren't
+running at all: a since-fixed bug had retries on the authenticated client
+silently never fire for any method or error (see the SDK changelog, v3.2.0).
+Now that they do, a `GET` hitting this can be retried — though a retry may
+still draw the same poisoned connection from the pool, so
+`freshConnectionConfig()` stays necessary.
 
 ## `addUser` requires a non-empty `proxies`
 

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -61,10 +61,13 @@ with a named export — don't have the consumer reach past it.
    is assigned to a facade field by hand in `MarzbanSDK.ts` (e.g.
    `this.node = new nodeApi({ client: http.client })`) — this wiring is the
    one place per module that isn't generated.
-3. Request interceptor waits for any in-flight auth (`authService.waitForCurrentAuth()`),
-   then attaches `Authorization`. Response interceptor retries once on `401`
-   after a re-login. `axios-retry` is layered on both instances for transient
-   network failures with exponential backoff.
+3. `axios-retry` is installed on both instances _before_ the auth
+   interceptors — it needs the raw `AxiosError`, which auth wraps into
+   `HttpError`. Each instance gets its own `retryCondition`: `client` retries
+   only GET/HEAD/OPTIONS, `publicClient` (login) also retries POST. Request
+   interceptor then waits for any in-flight auth (`authService.waitForCurrentAuth()`)
+   and attaches `Authorization`; response interceptor retries once on `401`
+   after a re-login.
 4. Every error is wrapped into `SdkError` (or a subclass) **before** it
    reaches the logger — `redactSecrets()` runs inside the `SdkError`
    constructor and again in the default logger, so a raw `AxiosError`

--- a/packages/sdk/src/core/http/client.retry.test.ts
+++ b/packages/sdk/src/core/http/client.retry.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AnyType } from '@/common'
+import { HttpError } from '@/core/errors'
+
+import { configureHttpClient } from './client'
+
+// Real axios + axios-retry + auth interceptors, transport swapped for a
+// counting fake adapter — the only way to prove the full chain (ordering +
+// retryCondition) behaves correctly end to end. client.test.ts mocks both
+// axios and axios-retry, so it can't observe this.
+
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+const makeAuthService = () =>
+  ({
+    waitForCurrentAuth: vi.fn().mockResolvedValue(undefined),
+    accessToken: 'token',
+    authenticate: vi.fn().mockResolvedValue(undefined),
+  }) as AnyType
+
+const makeConfig = (retries = 2) => ({ timeout: 30_000, retries }) as AnyType
+
+class FakeAxiosError extends Error {
+  isAxiosError = true
+  code?: string
+  config: AnyType
+  response?: { status: number; statusText: string; data: undefined; headers: object; config: AnyType }
+
+  constructor(config: AnyType, opts: { code?: string; status?: number }) {
+    super(opts.code ?? `status ${opts.status}`)
+    this.code = opts.code
+    this.config = config
+    if (opts.status !== undefined) {
+      this.response = { status: opts.status, statusText: '', data: undefined, headers: {}, config }
+    }
+  }
+}
+
+/** An adapter that fails `failCount` times with `failWith`, then succeeds. */
+const makeAdapter = (failCount: number, failWith: { code?: string; status?: number }) => {
+  const state = { calls: 0 }
+  const adapter = async (config: AnyType) => {
+    state.calls += 1
+    if (state.calls <= failCount) throw new FakeAxiosError(config, failWith)
+    return { data: 'ok', status: 200, statusText: 'OK', headers: {}, config }
+  }
+  return { adapter, state }
+}
+
+describe('configureHttpClient (real axios-retry stack)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('never retries a POST, even on a network error', async () => {
+    vi.useFakeTimers()
+    const { adapter, state } = makeAdapter(3, { code: 'ECONNRESET' })
+    const { client } = configureHttpClient('https://x', makeAuthService(), makeConfig(), logger)
+
+    const pending = client({ url: '/restart', method: 'post', adapter } as AnyType).catch(e => e)
+    await vi.runAllTimersAsync()
+    const error = await pending
+
+    expect(state.calls).toBe(1)
+    expect(error).toBeInstanceOf(HttpError)
+  })
+
+  it('retries a GET on a network error up to the configured limit', async () => {
+    vi.useFakeTimers()
+    const { adapter, state } = makeAdapter(3, { code: 'ECONNRESET' })
+    const { client } = configureHttpClient('https://x', makeAuthService(), makeConfig(2), logger)
+
+    const pending = client({ url: '/foo', method: 'get', adapter } as AnyType).catch(e => e)
+    await vi.runAllTimersAsync()
+    const error = await pending
+
+    expect(state.calls).toBe(3) // 1 initial + 2 retries
+    expect(error).toBeInstanceOf(HttpError)
+  })
+
+  it('retries a GET on a 500 and resolves once the adapter recovers', async () => {
+    vi.useFakeTimers()
+    const { adapter, state } = makeAdapter(2, { status: 500 })
+    const { client } = configureHttpClient('https://x', makeAuthService(), makeConfig(2), logger)
+
+    const pending = client({ url: '/foo', method: 'get', adapter } as AnyType)
+    await vi.runAllTimersAsync()
+    const response = await pending
+
+    expect(state.calls).toBe(3)
+    expect(response).toMatchObject({ data: 'ok' })
+  })
+
+  it('does not retry a GET on a 404', async () => {
+    const { adapter, state } = makeAdapter(1, { status: 404 })
+    const { client } = configureHttpClient('https://x', makeAuthService(), makeConfig(), logger)
+
+    const error = await client({ url: '/foo', method: 'get', adapter } as AnyType).catch(e => e)
+
+    expect(state.calls).toBe(1)
+    expect((error as HttpError).status).toBe(404)
+  })
+
+  it('retries a login POST on the public client', async () => {
+    vi.useFakeTimers()
+    const { adapter, state } = makeAdapter(1, { code: 'ECONNRESET' })
+    const { publicClient } = configureHttpClient('https://x', makeAuthService(), makeConfig(), logger)
+
+    const pending = publicClient({ url: '/login', method: 'post', adapter } as AnyType)
+    await vi.runAllTimersAsync()
+    const response = await pending
+
+    expect(state.calls).toBe(2)
+    expect(response).toMatchObject({ data: 'ok' })
+  })
+
+  it('re-authenticates once on a 401 without engaging the retry loop', async () => {
+    const { adapter, state } = makeAdapter(1, { status: 401 })
+    const authService = makeAuthService()
+    const { client } = configureHttpClient('https://x', authService, makeConfig(), logger)
+
+    const response = await client({ url: '/foo', method: 'get', adapter } as AnyType)
+
+    expect(authService.authenticate).toHaveBeenCalledTimes(1)
+    expect(state.calls).toBe(2)
+    expect(response).toMatchObject({ data: 'ok' })
+  })
+})

--- a/packages/sdk/src/core/http/client.test.ts
+++ b/packages/sdk/src/core/http/client.test.ts
@@ -95,6 +95,15 @@ describe('configureHttpClient', () => {
     expect(retryDelay(10)).toBe(30_000) // capped at MAX_RETRY_DELAY_MS
   })
 
+  it('installs axios-retry before the auth interceptors, so retry sees the raw AxiosError', () => {
+    configureHttpClient('https://x', authService, makeConfig(), logger)
+
+    // See client.ts: reversing this order makes retries silently no-op.
+    const retryCallOrder = axiosRetryMock.mock.invocationCallOrder[0]
+    const authInterceptorCallOrder = created[0].interceptors.response.use.mock.invocationCallOrder[0]
+    expect(retryCallOrder).toBeLessThan(authInterceptorCallOrder)
+  })
+
   describe('custom agents', () => {
     const httpAgent = { destroy: vi.fn() }
     const httpsAgent = { destroy: vi.fn() }

--- a/packages/sdk/src/core/http/client.test.ts
+++ b/packages/sdk/src/core/http/client.test.ts
@@ -95,6 +95,17 @@ describe('configureHttpClient', () => {
     expect(retryDelay(10)).toBe(30_000) // capped at MAX_RETRY_DELAY_MS
   })
 
+  it('scopes retries to safe methods on the authenticated client, plus POST on the public client', () => {
+    configureHttpClient('https://x', authService, makeConfig(), logger)
+
+    const { retryCondition: authCondition } = axiosRetryMock.mock.calls[0][1]
+    const { retryCondition: publicCondition } = axiosRetryMock.mock.calls[1][1]
+
+    expect(authCondition({ config: { method: 'post' }, response: { status: 500 } })).toBe(false)
+    expect(authCondition({ config: { method: 'get' }, response: { status: 500 } })).toBe(true)
+    expect(publicCondition({ config: { method: 'post' }, response: { status: 500 } })).toBe(true)
+  })
+
   it('installs axios-retry before the auth interceptors, so retry sees the raw AxiosError', () => {
     configureHttpClient('https://x', authService, makeConfig(), logger)
 

--- a/packages/sdk/src/core/http/client.ts
+++ b/packages/sdk/src/core/http/client.ts
@@ -8,6 +8,7 @@ import { MAX_RETRY_DELAY_MS, RETRY_BASE_DELAY_MS, ValidatedConfig } from '@/conf
 import { AuthManager } from '../auth'
 import { Logger } from '../logger'
 import { setupAuthInterceptors } from './interceptors'
+import { createRetryCondition, LOGIN_RETRYABLE_METHODS, SAFE_HTTP_METHODS } from './retry'
 
 function createClientFromAxios(instance: AxiosInstance): Client {
   return requestConfig => instance.request(requestConfig)
@@ -70,8 +71,8 @@ export const configureHttpClient = (
   // into HttpError, which has no .config — registering it first would make
   // axios-retry silently no-op.
   logger.debug(`Configuring retry logic: ${retries} retries with exponential backoff`, 'HttpClient')
-  axiosRetry(instanceAxios, { retries, retryDelay })
-  axiosRetry(instancePublic, { retries, retryDelay })
+  axiosRetry(instanceAxios, { retries, retryDelay, retryCondition: createRetryCondition(SAFE_HTTP_METHODS) })
+  axiosRetry(instancePublic, { retries, retryDelay, retryCondition: createRetryCondition(LOGIN_RETRYABLE_METHODS) })
 
   logger.debug('Setting up authentication interceptors', 'HttpClient')
   setupAuthInterceptors(instanceAxios, authService, config, logger)

--- a/packages/sdk/src/core/http/client.ts
+++ b/packages/sdk/src/core/http/client.ts
@@ -57,9 +57,6 @@ export const configureHttpClient = (
   const instanceAxios = axios.create({ baseURL: baseUrl, timeout: config.timeout, ...agentOptions })
   const instancePublic = axios.create({ baseURL: baseUrl, timeout: config.timeout, ...agentOptions })
 
-  logger.debug('Setting up authentication interceptors', 'HttpClient')
-  setupAuthInterceptors(instanceAxios, authService, config, logger)
-
   const retries = config.retries
   // Exponential backoff capped at MAX_RETRY_DELAY_MS: 1s, 2s, 4s, 8s, ...
   const retryDelay = (retryCount: number): number => {
@@ -68,9 +65,16 @@ export const configureHttpClient = (
     return delay
   }
 
+  // Must run before setupAuthInterceptors: axios-retry needs the raw
+  // AxiosError (error.config) to decide whether to retry. Auth wraps errors
+  // into HttpError, which has no .config — registering it first would make
+  // axios-retry silently no-op.
   logger.debug(`Configuring retry logic: ${retries} retries with exponential backoff`, 'HttpClient')
   axiosRetry(instanceAxios, { retries, retryDelay })
   axiosRetry(instancePublic, { retries, retryDelay })
+
+  logger.debug('Setting up authentication interceptors', 'HttpClient')
+  setupAuthInterceptors(instanceAxios, authService, config, logger)
 
   return {
     client: createClientFromAxios(instanceAxios),

--- a/packages/sdk/src/core/http/retry.test.ts
+++ b/packages/sdk/src/core/http/retry.test.ts
@@ -1,0 +1,75 @@
+import { AxiosError } from 'axios'
+import { describe, expect, it } from 'vitest'
+
+import { AnyType } from '@/common'
+
+import { createRetryCondition, LOGIN_RETRYABLE_METHODS, SAFE_HTTP_METHODS } from './retry'
+
+const makeError = (over: { method?: string; status?: number; code?: string }): AxiosError => {
+  return {
+    config: over.method ? { method: over.method } : undefined,
+    response: over.status !== undefined ? { status: over.status } : undefined,
+    code: over.code,
+    isAxiosError: true,
+  } as AnyType
+}
+
+describe('createRetryCondition', () => {
+  const isSafeRetryable = createRetryCondition(SAFE_HTTP_METHODS)
+
+  it.each(['get', 'head', 'options', 'GET', 'Head'])('retries %s on a network error', method => {
+    expect(isSafeRetryable(makeError({ method, code: 'ECONNRESET' }))).toBe(true)
+  })
+
+  it.each([500, 502, 503, 504, 429])('retries a safe method on status %d', status => {
+    expect(isSafeRetryable(makeError({ method: 'get', status }))).toBe(true)
+  })
+
+  it.each(['post', 'put', 'patch', 'delete'])('never retries %s, even on a network error', method => {
+    expect(isSafeRetryable(makeError({ method, code: 'ECONNRESET' }))).toBe(false)
+  })
+
+  it.each(['post', 'put', 'delete'])('never retries %s on a 500', method => {
+    expect(isSafeRetryable(makeError({ method, status: 500 }))).toBe(false)
+  })
+
+  it('does not retry a safe method on a 404', () => {
+    expect(isSafeRetryable(makeError({ method: 'get', status: 404 }))).toBe(false)
+  })
+
+  it('does not retry a safe method on a 401', () => {
+    expect(isSafeRetryable(makeError({ method: 'get', status: 401 }))).toBe(false)
+  })
+
+  it('does not retry a cancelled request (ERR_CANCELED)', () => {
+    expect(isSafeRetryable(makeError({ method: 'get', code: 'ERR_CANCELED' }))).toBe(false)
+  })
+
+  it('does not retry a timed-out request (ECONNABORTED)', () => {
+    expect(isSafeRetryable(makeError({ method: 'get', code: 'ECONNABORTED' }))).toBe(false)
+  })
+
+  it('does not retry when the method is missing', () => {
+    expect(isSafeRetryable(makeError({ code: 'ECONNRESET' }))).toBe(false)
+  })
+
+  describe('LOGIN_RETRYABLE_METHODS', () => {
+    const isLoginRetryable = createRetryCondition(LOGIN_RETRYABLE_METHODS)
+
+    it('retries a login POST on a network error', () => {
+      expect(isLoginRetryable(makeError({ method: 'post', code: 'ECONNRESET' }))).toBe(true)
+    })
+
+    it('retries a login POST on a 500', () => {
+      expect(isLoginRetryable(makeError({ method: 'post', status: 500 }))).toBe(true)
+    })
+
+    it('does not retry a login POST on a 404', () => {
+      expect(isLoginRetryable(makeError({ method: 'post', status: 404 }))).toBe(false)
+    })
+
+    it('still never retries put/delete', () => {
+      expect(isLoginRetryable(makeError({ method: 'delete', code: 'ECONNRESET' }))).toBe(false)
+    })
+  })
+})

--- a/packages/sdk/src/core/http/retry.ts
+++ b/packages/sdk/src/core/http/retry.ts
@@ -1,0 +1,29 @@
+import { AxiosError } from 'axios'
+import axiosRetry from 'axios-retry'
+
+export const SAFE_HTTP_METHODS = ['get', 'head', 'options'] as const
+
+/** Login is the one POST safe to replay: it's stateless, re-issuing a token has no side effects. */
+export const LOGIN_RETRYABLE_METHODS = [...SAFE_HTTP_METHODS, 'post'] as const
+
+/**
+ * Unlike axios-retry's default (`isNetworkOrIdempotentRequestError`), the
+ * method check runs first and gates everything else — a network error on a
+ * disallowed method is never retried.
+ */
+export const createRetryCondition = (retryableMethods: readonly string[]) => {
+  const allowed = new Set(retryableMethods)
+
+  return (error: AxiosError): boolean => {
+    const method = error.config?.method?.toLowerCase()
+    if (!method || !allowed.has(method)) return false
+
+    const status = error.response?.status
+    if (status !== undefined) return status === 429 || (status >= 500 && status <= 599)
+
+    // No response: a genuine network failure. Reuse axios-retry's own check
+    // (excludes ERR_CANCELED/ECONNABORTED) rather than axiosRetry.isSafeRequestError,
+    // which would retry a cancelled request via AbortSignal.
+    return axiosRetry.isNetworkError(error)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #75, and #91 found along the way.

While narrowing `retryCondition` per #75, found that retries on the authenticated client (`instanceAxios`) weren't running at all — for any method or error. `axios-retry` was installed *after* the auth interceptors, which wrap every error into `HttpError` before axios-retry ever sees it; `HttpError` has no `.config`, so axios-retry silently gave up. Fixed both in this PR, since #75's method scoping only matters once retries actually fire.

- **#91** — moved `axios-retry` before `setupAuthInterceptors` so it sees the raw `AxiosError`.
- **#75** — added an explicit `retryCondition`: only `GET`/`HEAD`/`OPTIONS` are retried on the authenticated client (network errors or 429/5xx), plus `POST` on the login request only (stateless, safe to replay). `POST`/`PUT`/`PATCH`/`DELETE` are never retried on the API client, including on network errors.
- Docs updated: `http-retry.mdx`, `config-options.mdx`, a new `v3.2.0` entry in `resources/changelog.mdx`, the now-answered open question in `docs/marzban-quirks.md`, and `packages/sdk/ARCHITECTURE.md`.

No public API changes — `retries` config option is unchanged. Version not bumped (bumped once per milestone).

## Test plan

- [x] `pnpm --filter marzban-sdk test:coverage` — 638 tests, 100% coverage
- [x] `pnpm --filter marzban-sdk lint` / `types:check`
- [x] `pnpm format:check`
- [x] New `client.retry.test.ts` exercises the real axios + axios-retry + auth-interceptor stack: POST never retries (network error or 5xx), GET retries and recovers, 404 doesn't retry, login POST retries, 401 re-auth isn't affected by the retry loop
- [x] `pnpm --filter marzban-sdk test:integration` against a local panel — 70/70 passing, including the `removeUser` poisoned-socket scenario in `marzban-quirks.md`