### PR TITLE
Read HTTP status from HttpError instead of duck-typing it in MCP

### DIFF
--- a/apps/docs/content/docs/get-started/quick-start.mdx
+++ b/apps/docs/content/docs/get-started/quick-start.mdx
@@ -67,7 +67,7 @@ try {
   if (isAuthError(err)) {
     console.error('Authentication failed:', err.message)
   } else if (isHttpError(err)) {
-    console.error('HTTP error:', err.message, err.details)
+    console.error('HTTP error:', err.status, err.message)
   } else {
     throw err
   }

--- a/packages/mcp/src/core/errors/to-tool-error.test.ts
+++ b/packages/mcp/src/core/errors/to-tool-error.test.ts
@@ -32,33 +32,28 @@ describe('toToolError', () => {
     expect(text).toContain('MARZBAN_USERNAME/MARZBAN_PASSWORD')
   })
 
-  it('renders an HttpError with the extracted HTTP status when present', () => {
+  it('renders an HttpError with its HTTP status when present', () => {
     const result = toToolError(new HttpError({ response: { status: 404 } }))
     const text = (result.content[0] as { text: string }).text
     expect(text).toContain('HTTP 404')
   })
 
-  it('renders an HttpError without a status suffix when none can be extracted', () => {
+  it('renders an HttpError without a status suffix when none is available', () => {
     const result = toToolError(new HttpError('network down'))
     const text = (result.content[0] as { text: string }).text
     expect(text).not.toMatch(/\(HTTP \d+\)/)
     expect(text).toContain('Marzban API request failed')
   })
 
-  it('does not crash extracting a status from a non-object details value', () => {
-    const result = toToolError(new HttpError('just a string'))
+  it.each([
+    ['a non-object details value', 'just a string'],
+    ['a details.response that is not an object', { response: 'nope' }],
+    ['a non-numeric response.status', { response: { status: 'nope' } }],
+  ])('does not crash and omits the status suffix for %s', (_label, details) => {
+    const result = toToolError(new HttpError(details))
     expect(result.isError).toBe(true)
-  })
-
-  it('omits the status suffix when response.status is present but not a number', () => {
-    const result = toToolError(new HttpError({ response: { status: 'nope' } }))
     const text = (result.content[0] as { text: string }).text
     expect(text).not.toMatch(/\(HTTP /)
-  })
-
-  it('does not crash extracting a status from a details.response that is not an object', () => {
-    const result = toToolError(new HttpError({ response: 'nope' }))
-    expect(result.isError).toBe(true)
   })
 
   it('renders a ConfigurationError with an actionable hint', () => {

--- a/packages/mcp/src/core/errors/to-tool-error.ts
+++ b/packages/mcp/src/core/errors/to-tool-error.ts
@@ -6,18 +6,6 @@ import { redactText } from '@/shared/redact-text'
 
 import { ToolError } from './mcp.error'
 
-// HttpError.details wraps a raw axios error (redacted, but still `unknown` —
-// marzban-sdk doesn't type it yet, tracked as P3). Duck-typing the status out
-// of it is the same best-effort every other current consumer of the SDK has
-// to do; there's no safer option until P3 lands.
-function extractHttpStatus(details: unknown): number | undefined {
-  if (typeof details !== 'object' || details === null) return undefined
-  const response = (details as { response?: unknown }).response
-  if (typeof response !== 'object' || response === null) return undefined
-  const status = (response as { status?: unknown }).status
-  return typeof status === 'number' ? status : undefined
-}
-
 function textResult(text: string): CallToolResult {
   return { content: [{ type: 'text', text: redactText(text) }], isError: true }
 }
@@ -41,9 +29,8 @@ export function toToolError(error: unknown): CallToolResult {
   }
 
   if (isHttpError(error)) {
-    const status = extractHttpStatus(error.details)
-    const statusText = status ? ` (HTTP ${status})` : ''
-    return textResult(`Marzban API request failed${statusText}: ${error.message}`)
+    const suffix = error.status === undefined ? '' : ` (HTTP ${error.status})`
+    return textResult(`Marzban API request failed${suffix}: ${error.message}`)
   }
 
   if (isConfigurationError(error)) {


### PR DESCRIPTION
## Summary

Closes #81 (the MCP-side cleanup — the SDK-side typed accessor was already added in c4a5b36 / sdk-v3.1.0).

- `packages/mcp/src/core/errors/to-tool-error.ts` now reads `error.status` directly instead of duck-typing it out of `HttpError.details`; the local `extractHttpStatus` helper and its P3 comment are gone.
- Tests updated to match; three near-duplicate "malformed details" cases collapsed into one `it.each`.
- The quick-start docs example now shows `err.status` instead of raw `err.details`, consistent with the error-handling guide.

## Test plan

- [x] `pnpm --filter marzban-mcp test`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test`