### PR TITLE
test(sdk): add integration coverage for the Node module

### DIFF
--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -252,3 +252,77 @@ after a revoke.
 invalidates a previously-issued subscription link; it doesn't, by design.
 See
 [`subscription.integration.test.ts`](../packages/sdk/test/integration/subscription.integration.test.ts).
+
+## `removeNode` deletes the node but leaves its auto-added host behind
+
+**Verified against:** `gozargah/marzban:latest`, `local/marzban/`.
+
+`addNode({ add_as_new_host: true })` (the default) adds a proxy host entry
+for the node under its inbound tag, with `remark` containing the node's
+name and `address` set to the node's address. `removeNode` deletes the node
+row but does not remove that host entry — it's left in the host map,
+pointing at an address that no longer resolves to any node, until removed
+manually via `modifyHosts`.
+
+**Workaround:** none needed at the SDK level — a caller that creates a node
+with `add_as_new_host: true` and later removes it should also clean up the
+corresponding host entry itself. See
+[`node-hosts.integration.test.ts`](../packages/sdk/test/integration/node-hosts.integration.test.ts),
+which restores the host map from a snapshot in `afterAll` rather than
+relying on `removeNode` to have cleaned up after itself.
+
+**Open:** not tested against a panel with more than one inbound tag, or
+against `add_as_new_host: false` followed by a separate manual host add —
+only the default create-then-remove path was verified.
+
+## `addNode` fires an async connection attempt immediately, which can race a follow-up `modifyNode`
+
+**Verified against:** `gozargah/marzban:latest`, `local/marzban/`, panel
+container logs (`INFO: Connecting to "<name>" node` /
+`INFO: Unable to connect to "<name>" node`).
+
+`addNode` schedules a background task that tries to connect to the node's
+`api_port` right away — not on a delay or a periodic cycle. Against an
+address nothing is listening on, that task fails fast (sub-millisecond on
+loopback) and writes `status: 'error'` plus a `message`. If a `modifyNode`
+call — including one that explicitly sets `status: 'disabled'` — lands
+while that task is still in flight, the two writes race: depending on
+ordering, the task's failure write can land _after_ the disable and silently
+overwrite both `status` (back to `'error'`) and `message`, even though the
+`modifyNode` call itself returned `status: 'disabled'`. Reproduced via the
+SDK's own back-to-back calls (curl invocations, with their extra
+process-spawn latency between requests, consistently missed the window and
+never showed it).
+
+**Workaround:** poll `getNode` until `status` is no longer `'connecting'`
+before modifying a freshly created node — `waitForNodeSettled()` in
+[`nodeFixture.ts`](../packages/sdk/test/integration/helpers/nodeFixture.ts),
+used by
+[`node.integration.test.ts`](../packages/sdk/test/integration/node.integration.test.ts)'s
+disable test. Once the connection attempt has resolved, there's nothing
+left to race.
+
+**Open:** the SDK itself doesn't special-case this — a real caller that
+disables a node right after creating it can observe the same lost update.
+Whether `modifyNode` on an _existing, already-settled_ node ever re-triggers
+this same async check (as opposed to only on create) wasn't characterized.
+
+## `addNode` ignores `usage_coefficient` on create — always stores `1.0`
+
+**Verified against:** `gozargah/marzban:latest`, `local/marzban/`.
+
+`NodeCreate.usage_coefficient` type-checks and the request accepts any
+value `> 0`, but the panel always stores `1.0` for a newly created node
+regardless of what was sent — the field is silently dropped on the create
+path only. `modifyNode({ usage_coefficient })` on an existing node works as
+documented: the value is stored and echoed back.
+
+**Workaround:** none needed once known — set `usage_coefficient` with a
+follow-up `modifyNode` call if it needs to be anything other than the
+default. See
+[`node.integration.test.ts`](../packages/sdk/test/integration/node.integration.test.ts),
+which asserts the create response always has `usage_coefficient: 1` and
+verifies the field only through `modifyNode`.
+
+**Open:** whether this is intentional or a panel bug wasn't investigated
+further.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,19 +54,19 @@ pnpm --filter marzban-sdk test:coverage
   suites had to
   work around — 500s that should succeed, fields that normalize on the wire,
   etc. — is centralized in [marzban-quirks.md](./marzban-quirks.md) rather
-  than commented inline everywhere it's relevant. The `core` and `system`
-  suites additionally mutate live, panel-wide state (the xray core config,
-  the proxy host map) — each takes a snapshot in `beforeAll` and restores +
-  deep-equal-asserts it in `afterAll`, so a failure fails loudly in its own
-  file instead of silently breaking the files that run after it
-  (`fileParallelism: false`). If a run is ever interrupted mid-mutation,
-  `pnpm local:reset` gets the panel back to a known state.
+  than commented inline everywhere it's relevant. The `core`, `system`, and
+  `node-hosts` suites additionally mutate live, panel-wide state (the xray
+  core config, the proxy host map) — each takes a snapshot in `beforeAll`
+  and restores + deep-equal-asserts it in `afterAll`, so a failure fails
+  loudly in its own file instead of silently breaking the files that run
+  after it (`fileParallelism: false`). If a run is ever interrupted
+  mid-mutation, `pnpm local:reset` gets the panel back to a known state.
 
   `sdk` module coverage:
   - [x] User
   - [x] Admin
   - [x] Core
-  - [ ] Node
+  - [x] Node
   - [x] Subscription
   - [x] System
   - [x] UserTemplate

--- a/packages/sdk/test/integration/helpers/nodeFixture.ts
+++ b/packages/sdk/test/integration/helpers/nodeFixture.ts
@@ -1,0 +1,51 @@
+import { isHttpError, type MarzbanSDK, type NodeCreate, type NodeResponse } from '../../../src/index'
+import { uniqueTestName } from './cleanup'
+
+/**
+ * Address/port pair that is syntactically valid but has nothing listening —
+ * the node reliably settles on `status: 'error'` (`[Errno 111] Connection
+ * refused`) rather than ever reaching `connected`, since `local/marzban/`
+ * has no `marzban-node` container to actually connect to.
+ */
+export function createTestNode(
+  sdk: MarzbanSDK,
+  overrides: Partial<NodeCreate> = {}
+): ReturnType<MarzbanSDK['node']['addNode']> {
+  return sdk.node.addNode({
+    name: uniqueTestName('node'),
+    address: '127.0.0.1',
+    port: 62050,
+    api_port: 62051,
+    add_as_new_host: false,
+    ...overrides,
+  })
+}
+
+/**
+ * Polls `getNode` until its background connection attempt (fired
+ * immediately on `addNode`/`modifyNode`, see docs/marzban-quirks.md) has
+ * finished and `status` is no longer `'connecting'`. Needed before any test
+ * that itself calls `modifyNode` on a freshly created node — modifying a
+ * node while that connection attempt is still in flight races it, and the
+ * attempt's failure handler can silently overwrite the modification.
+ */
+export async function waitForNodeSettled(sdk: MarzbanSDK, nodeId: number, timeoutMs = 15_000): Promise<NodeResponse> {
+  const deadline = Date.now() + timeoutMs
+  let last: NodeResponse
+  do {
+    last = await sdk.node.getNode(nodeId)
+    if (last.status !== 'connecting') return last
+    await new Promise(resolve => setTimeout(resolve, 100))
+  } while (Date.now() < deadline)
+  throw new Error(`node ${nodeId} did not settle within ${timeoutMs}ms (last: ${JSON.stringify(last)})`)
+}
+
+/** `removeNode` counterpart to {@link removeAdminTolerantly} — swallows "already gone", not a known 500 quirk here. */
+export async function removeNodeTolerantly(sdk: MarzbanSDK, nodeId: number): Promise<void> {
+  try {
+    await sdk.node.removeNode(nodeId)
+  } catch (err) {
+    if (isHttpError(err) && err.status === 404) return
+    throw err
+  }
+}

--- a/packages/sdk/test/integration/node-hosts.integration.test.ts
+++ b/packages/sdk/test/integration/node-hosts.integration.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import type { MarzbanSDK, ProxyHost } from '../../src/index'
+import { createCleanupRegistry, uniqueTestName } from './helpers/cleanup'
+import { createTestSdk } from './helpers/client'
+import { createTestNode, removeNodeTolerantly } from './helpers/nodeFixture'
+import { restoreHosts, snapshotHosts } from './helpers/systemFixture'
+
+// The only node test that mutates the panel's live proxy host map
+// (addNode's add_as_new_host: true default). A snapshot is taken once in
+// beforeAll and restored — with a deep-equal assertion, not just a
+// best-effort write — after the suite (see core.integration.test.ts for
+// the same pattern and why it matters under fileParallelism: false).
+// Everything else about node CRUD lives in node.integration.test.ts, which
+// always passes add_as_new_host: false.
+describe('node integration (add_as_new_host host map mutation)', () => {
+  let sdk: MarzbanSDK
+  let hostsSnapshot: Record<string, ProxyHost[]>
+  let inboundTag: string
+  const cleanup = createCleanupRegistry()
+
+  beforeAll(async () => {
+    sdk = await createTestSdk()
+    hostsSnapshot = await snapshotHosts(sdk)
+    inboundTag = Object.keys(hostsSnapshot)[0]!
+  })
+
+  afterEach(async () => {
+    await cleanup.runAll()
+  })
+
+  afterAll(async () => {
+    await restoreHosts(sdk, hostsSnapshot)
+    await expect(sdk.system.getHosts()).resolves.toEqual(hostsSnapshot)
+    await sdk.destroy()
+  })
+
+  it('adds a host entry for the node under its inbound tag, and removeNode does not clean it up', async () => {
+    const node = await createTestNode(sdk, { name: uniqueTestName('node-host'), add_as_new_host: true })
+    cleanup.register(() => removeNodeTolerantly(sdk, node.id))
+    cleanup.register(() => restoreHosts(sdk, hostsSnapshot))
+
+    const hostsAfterAdd = await sdk.system.getHosts()
+    const added = (hostsAfterAdd[inboundTag] ?? []).find(h => h.address === node.address)
+    expect(added).toBeDefined()
+    expect(added!.remark).toContain(node.name)
+
+    // Verified live-panel quirk: removeNode deletes the node row but leaves
+    // the host entry it created behind — see docs/marzban-quirks.md.
+    await sdk.node.removeNode(node.id)
+    const hostsAfterRemove = await sdk.system.getHosts()
+    const stillThere = (hostsAfterRemove[inboundTag] ?? []).find(h => h.address === node.address)
+    expect(stillThere).toBeDefined()
+  })
+})

--- a/packages/sdk/test/integration/node.integration.test.ts
+++ b/packages/sdk/test/integration/node.integration.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import type { HttpError, MarzbanSDK } from '../../src/index'
+import { createTestAdmin, removeAdminTolerantly } from './helpers/adminFixture'
+import { createCleanupRegistry, uniqueTestName } from './helpers/cleanup'
+import { createTestSdk } from './helpers/client'
+import { createTestNode, removeNodeTolerantly, waitForNodeSettled } from './helpers/nodeFixture'
+
+// Every test here creates nodes with add_as_new_host: false, so nothing
+// touches the panel's proxy host map — the one node test that does
+// (add_as_new_host: true) lives in its own file, node-hosts.integration.test.ts,
+// with the snapshot/restore lifecycle that kind of panel-wide mutation needs.
+describe('node integration (settings, usage, CRUD)', () => {
+  let sdk: MarzbanSDK
+  const cleanup = createCleanupRegistry()
+
+  beforeAll(async () => {
+    sdk = await createTestSdk()
+  })
+
+  afterEach(async () => {
+    await cleanup.runAll()
+  })
+
+  afterAll(async () => {
+    await sdk.destroy()
+  })
+
+  it('returns the node client certificate and minimum version from getNodeSettings', async () => {
+    const settings = await sdk.node.getNodeSettings()
+
+    expect(settings.certificate).toContain('-----BEGIN CERTIFICATE-----')
+    expect(settings.min_node_version).toEqual(expect.any(String))
+  })
+
+  it('returns per-node usage including the master node with a null node_id', async () => {
+    const usage = await sdk.node.getUsage()
+
+    expect(Array.isArray(usage.usages)).toBe(true)
+    const master = usage.usages.find(u => u.node_name === 'Master')
+    expect(master).toBeDefined()
+    expect(master!.node_id).toBeNull()
+    for (const entry of usage.usages) {
+      expect(entry.node_name).toEqual(expect.any(String))
+      expect(Number.isInteger(entry.uplink)).toBe(true)
+      expect(Number.isInteger(entry.downlink)).toBe(true)
+    }
+  })
+
+  it('creates, fetches, lists, partially updates, and removes a node (happy path)', async () => {
+    const name = uniqueTestName('node-happy')
+
+    const created = await createTestNode(sdk, { name, port: 62060, api_port: 62061, usage_coefficient: 2 })
+    cleanup.register(() => removeNodeTolerantly(sdk, created.id))
+    expect(created.name).toBe(name)
+    expect(created.address).toBe('127.0.0.1')
+    expect(created.port).toBe(62060)
+    expect(created.api_port).toBe(62061)
+    // docs/marzban-quirks.md: addNode ignores usage_coefficient on create —
+    // always stores 1, regardless of the 2 requested above.
+    expect(created.usage_coefficient).toBe(1)
+    // Unreachable address (see nodeFixture.ts) — the node never reaches
+    // 'connected' on this stand, only 'connecting' or 'error'.
+    expect(['connecting', 'error']).toContain(created.status)
+
+    const fetched = await sdk.node.getNode(created.id)
+    expect(fetched).toEqual(created)
+
+    const listed = await sdk.node.getNodes()
+    expect(listed.map(n => n.id)).toContain(created.id)
+
+    // Partial PATCH semantics: only usage_coefficient is sent, name/address/ports unchanged.
+    const modified = await sdk.node.modifyNode(created.id, { usage_coefficient: 3.5 })
+    expect(modified.usage_coefficient).toBe(3.5)
+    expect(modified.name).toBe(name)
+    expect(modified.address).toBe(created.address)
+    expect(modified.port).toBe(created.port)
+
+    await sdk.node.removeNode(created.id)
+    await expect(sdk.node.getNode(created.id)).rejects.toMatchObject({
+      status: 404,
+    } satisfies Partial<HttpError>)
+  })
+
+  it('modifying a node to status: disabled clears the connection error and is stable on read', async () => {
+    const created = await createTestNode(sdk)
+    cleanup.register(() => removeNodeTolerantly(sdk, created.id))
+
+    // docs/marzban-quirks.md: addNode fires an async connection attempt
+    // immediately; modifying the node while it's still in flight races it.
+    // Waiting for it to settle first makes the disable below deterministic.
+    const settled = await waitForNodeSettled(sdk, created.id)
+    expect(settled.status).toBe('error')
+    expect(settled.message).toEqual(expect.any(String))
+
+    const modified = await sdk.node.modifyNode(created.id, { status: 'disabled' })
+    expect(modified.status).toBe('disabled')
+    expect(modified.message).toBeNull()
+
+    const fetched = await sdk.node.getNode(created.id)
+    expect(fetched.status).toBe('disabled')
+    expect(fetched.message).toBeNull()
+  })
+
+  it('rejects creating a node with a name that already exists', async () => {
+    const name = uniqueTestName('node-dup')
+    const created = await createTestNode(sdk, { name })
+    cleanup.register(() => removeNodeTolerantly(sdk, created.id))
+
+    await expect(createTestNode(sdk, { name, address: '127.0.0.2' })).rejects.toMatchObject({
+      status: 409,
+    } satisfies Partial<HttpError>)
+  })
+
+  it('schedules a reconnection for an unreachable node without erroring', async () => {
+    const created = await createTestNode(sdk)
+    cleanup.register(() => removeNodeTolerantly(sdk, created.id))
+
+    // reconnectNode's response has no declared schema (NodeModel/ReconnectNode.ts
+    // types it `any`) — it's a plain "scheduled" acknowledgement, not a NodeResponse.
+    await expect(sdk.node.reconnectNode(created.id)).resolves.not.toThrow()
+  })
+
+  it('rejects all node operations from a non-sudo admin session', async () => {
+    const { username, password } = await createTestAdmin(sdk)
+    cleanup.register(() => removeAdminTolerantly(sdk, username))
+
+    const created = await createTestNode(sdk)
+    cleanup.register(() => removeNodeTolerantly(sdk, created.id))
+
+    const nonSudoSdk = await createTestSdk({ username, password })
+    try {
+      await expect(nonSudoSdk.node.getNodes()).rejects.toMatchObject({ status: 403 } satisfies Partial<HttpError>)
+      await expect(nonSudoSdk.node.getNode(created.id)).rejects.toMatchObject({
+        status: 403,
+      } satisfies Partial<HttpError>)
+      await expect(nonSudoSdk.node.getNodeSettings()).rejects.toMatchObject({
+        status: 403,
+      } satisfies Partial<HttpError>)
+      await expect(nonSudoSdk.node.getUsage()).rejects.toMatchObject({ status: 403 } satisfies Partial<HttpError>)
+      await expect(createTestNode(nonSudoSdk)).rejects.toMatchObject({ status: 403 } satisfies Partial<HttpError>)
+      await expect(nonSudoSdk.node.modifyNode(created.id, { usage_coefficient: 5 })).rejects.toMatchObject({
+        status: 403,
+      } satisfies Partial<HttpError>)
+      await expect(nonSudoSdk.node.reconnectNode(created.id)).rejects.toMatchObject({
+        status: 403,
+      } satisfies Partial<HttpError>)
+      await expect(nonSudoSdk.node.removeNode(created.id)).rejects.toMatchObject({
+        status: 403,
+      } satisfies Partial<HttpError>)
+    } finally {
+      await nonSudoSdk.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `node.integration.test.ts` (getNodeSettings/getUsage reads, full CRUD, partial PATCH, non-sudo 403s) and `node-hosts.integration.test.ts` (the `add_as_new_host` proxy-host mutation, in its own snapshot/restore file) plus a `nodeFixture.ts` helper.
- Documents three live-panel quirks found along the way: `addNode` ignores `usage_coefficient` on create, `removeNode` leaves its auto-added host behind, and `addNode`'s async connection attempt can race a follow-up `modifyNode`.
- Ticks the Node box in `docs/testing.md`'s sdk coverage checklist.

Real `marzban-node` connectivity (status `connected`, non-null `xray_version`, non-zero usage) is out of scope — the local stand only runs the panel. Follow-up tracked separately if we want that stand.

Closes #82.

## Test plan
- [x] `pnpm --filter marzban-sdk test:integration` — 78/78 passing, run twice in a row to confirm panel state is fully restored
- [x] `pnpm test` — full unit suite passing
- [x] `pnpm build` — passing
- [x] `pnpm lint` — clean