### PR TITLE
test(sdk): real ws.Server test harness for the WS module

### DIFF
--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -326,3 +326,32 @@ verifies the field only through `modifyNode`.
 
 **Open:** whether this is intentional or a panel bug wasn't investigated
 further.
+
+## WebSocket log handshake rejections collapse into a generic HTTP 403
+
+**Verified against:** `gozargah/marzban:v0.8.4`, `local/marzban/`.
+
+The panel authorizes a `/api/core/logs`/`/api/node/{id}/logs` connection
+before calling `websocket.accept()` — an expired token, a non-sudo admin
+token, and an `interval` outside the accepted range (`> 10`) are all
+rejected at this stage. uvicorn collapses whatever close code the
+application logic intended (4401/4403/4400) into one generic HTTP 403 on the
+handshake response; the client sees only "403", never which of those three
+conditions caused it.
+
+**Workaround:** none at the panel level — a client can't distinguish "token
+expired" from "interval too large" from the handshake response alone.
+[`logs.integration.test.ts`](../packages/sdk/test/integration/logs.integration.test.ts)
+exercises this with `interval: 11` since it's the one variant reproducible
+without a real expired token. The synchronous mock fixture in
+[`packages/sdk/src/testing/mock-panel.ts`](../packages/sdk/src/testing/mock-panel.ts)
+models the same collapse: its `reject` handshake policy always closes before
+`websocket.accept()`, regardless of the reason a real caller configures it
+to simulate.
+
+**Open:** `LogsStream` currently treats every 403 as an expired token and
+retries with re-authentication — including the `interval` and non-sudo
+cases, where retrying can never succeed. Tracked in
+[issue #88](https://github.com/Ilmar7786/marzban-sdk/issues/88), which
+replaces this substring-of-the-error-message classification with one based
+on connection phase instead.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,6 +70,49 @@ pnpm --filter marzban-sdk test:coverage
   - [x] Subscription
   - [x] System
   - [x] UserTemplate
+  - [x] Logs (WebSocket) — smoke only, see "WS module" below for the detailed
+        timing coverage
+
+## WS module
+
+`core/ws` is the one module whose unit tests don't mock the transport with
+`vi.mock` (see "Network isolation" below) — `logs-stream.test.ts` mocks
+`WebSocketClient.create` itself with a synchronous fake instead, which
+cannot reproduce timing bugs that only show up with a real socket (a
+microtask gap between socket construction and listener attachment, an
+unsolicited `close`, a shutdown racing a reconnect). `packages/sdk/src/testing/`
+fixes that gap with a real `ws.Server` on loopback:
+
+- [`mock-panel.ts`](../packages/sdk/src/testing/mock-panel.ts) — one
+  `http.Server` standing in for the panel: serves `POST /api/admin/token`
+  and handles the WebSocket upgrade for everything else, mirroring how the
+  real panel authorizes a connection before `websocket.accept()` (see
+  [marzban-quirks.md](./marzban-quirks.md)). Handshakes can be configured to
+  accept, reject (with a status), delay, or hang; logins to succeed,
+  fail, or stall until released — enough to drive the real-socket timing
+  scenarios `logs-stream.test.ts`'s fake can't.
+- [`transports.ts`](../packages/sdk/src/testing/transports.ts) — forces
+  `WebSocketClient.create` onto the `ws`-package fallback for a test, so WS
+  behavior can be asserted on both transports it can resolve to.
+- Lives under `src/` rather than `test/`: `packages/sdk/tsconfig.json` sets
+  `rootDir: "./src"`, so a unit test under `src/core/ws/` importing a helper
+  from `test/` fails `tsc --noEmit` (`TS6059`) even though Vitest itself
+  would run it fine. Being under `src/` means it's covered by the 100%
+  threshold too — `mock-panel.test.ts`/`transports.test.ts` test the fixture
+  itself. It isn't exported from `src/index.ts`, so it never reaches the
+  published package (`tsup`'s only entry is `index.ts`; `files: ["dist"]`
+  in `package.json` ships only the build output regardless).
+- `logs-stream.server.test.ts` (next to `logs-stream.test.ts`) is where new
+  WS timing/lifecycle tests belong, built on this fixture instead of a
+  hand-rolled fake. `logs-stream.test.ts` itself stays — it still pins
+  `LogsStream`'s branch behavior efficiently — until it's replaced outright
+  once a public-API change lands (tracked alongside the reconnect rework in
+  [issue #88](https://github.com/Ilmar7786/marzban-sdk/issues/88)).
+
+Reconnect, connect-timeout, and shutdown-race scenarios are exercised on
+this fixture as those behaviors are implemented — see
+[issue #85](https://github.com/Ilmar7786/marzban-sdk/issues/85) for the
+fixture itself and the issues it unblocks.
 
 ## Coverage
 
@@ -88,9 +131,12 @@ A PR that drops coverage below 100% on either package fails
 There's no HTTP mock library (no msw, no nock) in this repo. The transport
 itself is mocked — `vi.mock('axios')` / `vi.mock('axios-retry')` — so tests
 exercise real request-building and error-handling logic against a fake
-client. [`local/marzban/README.md`](../local/marzban/README.md) has a disposable
-Docker panel for the "Integration" level above — and for ad hoc manual
-poking, which is still the faster loop for one-off checks.
+client. The WS module is the exception: `logs-stream.server.test.ts` and the
+fixture's own self-tests run against a real (loopback-only) `ws.Server`
+rather than a mocked transport — see "WS module" above for why a mock
+couldn't do the job there. [`local/marzban/README.md`](../local/marzban/README.md)
+has a disposable Docker panel for the "Integration" level above — and for ad
+hoc manual poking, which is still the faster loop for one-off checks.
 
 ```sh
 pnpm local:up && pnpm local:logs   # wait for it to report ready, then Ctrl+C

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -24,11 +24,20 @@ its own on top of HTTP.
 | `src/common/`  | Runtime-agnostic utilities with no domain knowledge (redaction, byte/buffer helpers, event emitter, environment detection). |
 | `src/gen/`     | Fully generated from OpenAPI via kubb — `api/`, `models/`, `schemas/`. Committed to git, never hand-edited.                 |
 | `src/helpers/` | Convenience utilities for SDK consumers (bytes, datetime, pagination) — not used by `core/`.                                |
+| `src/testing/` | Test-only fixtures — see below.                                                                                             |
 
 Dependency direction is one-way and acyclic: `index.ts → core/MarzbanSDK.ts →
 {config, core/*, gen/api}`. `common/` sits below everything and depends on
 nothing else in the package. `helpers/` is isolated on purpose — it's for
 consumers, not for `core/`.
+
+`src/testing/` holds fixtures used only by this package's own tests —
+currently the real-`ws.Server` harness for `core/ws` (see
+[`docs/testing.md`](../../docs/testing.md) "WS module"). It lives under
+`src/` rather than `test/` only because `rootDir: "./src"` in
+`tsconfig.json` breaks `types:check` for a unit test importing from outside
+`src/`; it isn't exported from `src/index.ts` and never reaches the built
+package (`tsup`'s only entry is `index.ts`).
 
 ## Public API barrier
 

--- a/packages/sdk/src/core/ws/logs-stream.server.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream.server.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createMarzbanSDK, type MarzbanSDK } from '@/core/MarzbanSDK'
+import type { MockPanel } from '@/testing'
+import { selectWsTransport, startMockPanel, WS_TRANSPORTS } from '@/testing'
+
+/**
+ * `LogsStream` exercised against the real-socket fixture from `src/testing/`
+ * instead of the synchronous fake in `logs-stream.test.ts` (see that file's
+ * header comment). Only asserts invariants expected to survive #86-#88's
+ * reconnect rework — no reconnect/retry/timeout scenarios here, those land
+ * with the rework that implements them.
+ */
+describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName => {
+  let panel: MockPanel
+  let sdk: MarzbanSDK | undefined
+
+  beforeEach(async () => {
+    selectWsTransport(transportName)
+    panel = await startMockPanel()
+  })
+
+  afterEach(async () => {
+    await sdk?.destroy()
+    await panel.stop()
+    vi.unstubAllGlobals()
+    sdk = undefined
+  })
+
+  async function connectSdk(): Promise<MarzbanSDK> {
+    sdk = await createMarzbanSDK({
+      baseUrl: panel.baseUrl,
+      username: 'admin',
+      password: 'secret',
+      retries: 0,
+      logger: false,
+    })
+    return sdk
+  }
+
+  it('sends the token obtained from login and the requested interval in the handshake', async () => {
+    const instance = await connectSdk()
+
+    await instance.logs.connectByCore({ interval: 7, onMessage: () => {} })
+
+    const [handshake] = await panel.waitForHandshakes(1)
+    expect(handshake!.pathname).toBe('/api/core/logs')
+    expect(handshake!.interval).toBe('7')
+    expect(handshake!.token).toBe('mock-access-token')
+    expect(panel.logins).toEqual([{ username: 'admin', password: 'secret' }])
+  })
+
+  it('delivers server messages to onMessage', async () => {
+    const instance = await connectSdk()
+    const received: unknown[] = []
+
+    await instance.logs.connectByCore({ onMessage: data => received.push(data) })
+    await panel.waitForConnection()
+    panel.broadcast('log line 1')
+
+    await vi.waitFor(() => expect(received).toEqual(['log line 1']))
+  })
+
+  it('closes the specific server socket when the returned close handle is called', async () => {
+    const instance = await connectSdk()
+
+    const close = await instance.logs.connectByCore({ onMessage: () => {} })
+    const [socket] = await panel.waitForConnections(1)
+    close()
+
+    await vi.waitFor(() => expect(socket!.readyState).toBe(socket!.CLOSED))
+  })
+
+  it('destroy() closes every open server socket', async () => {
+    const instance = await connectSdk()
+
+    await instance.logs.connectByCore({ onMessage: () => {} })
+    await instance.logs.connectByNode('node-1', { onMessage: () => {} })
+    const sockets = await panel.waitForConnections(2)
+
+    await instance.destroy()
+
+    await vi.waitFor(() => {
+      sockets.forEach(socket => expect(socket.readyState).toBe(socket.CLOSED))
+    })
+  })
+
+  it('a fresh login flows through to the next connection', async () => {
+    const instance = await connectSdk()
+
+    await instance.logs.connectByCore({ onMessage: () => {} })
+    await panel.waitForHandshakes(1)
+
+    panel.setLogin({ mode: 'ok', token: 'second-token' })
+    await instance.authorize()
+    await instance.logs.connectByCore({ onMessage: () => {} })
+
+    const handshakes = await panel.waitForHandshakes(2)
+    expect(handshakes[1]?.token).toBe('second-token')
+  })
+})

--- a/packages/sdk/src/core/ws/logs-stream.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream.test.ts
@@ -1,3 +1,11 @@
+// This file mocks `WebSocketClient.create` with a synchronous fake that
+// registers handlers immediately and closes only on command — it pins
+// branch coverage (which callback fires for which input), not timing. It
+// cannot reproduce microtask-gap or transport-level races (see issue #85);
+// new WS timing/lifecycle tests belong in `logs-stream.server.test.ts`,
+// built on the real `ws.Server` fixture in `src/testing/mock-panel.ts`.
+// This file is slated for replacement once #88 changes LogsStream's
+// public contract.
 import type { Mock } from 'vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -1,0 +1,4 @@
+export type { HandshakePolicy, LoginPolicy, MockPanel, RecordedHandshake, RecordedLogin } from './mock-panel'
+export { startMockPanel } from './mock-panel'
+export type { WsTransportName } from './transports'
+export { selectWsTransport, WS_TRANSPORTS } from './transports'

--- a/packages/sdk/src/testing/mock-panel.test.ts
+++ b/packages/sdk/src/testing/mock-panel.test.ts
@@ -1,0 +1,260 @@
+import http from 'node:http'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { WebSocket as WsClient } from 'ws'
+
+import type { AnyType } from '@/common/types'
+
+import type { MockPanel } from './mock-panel'
+import { startMockPanel } from './mock-panel'
+
+function wsUrl(panel: MockPanel, path: string): string {
+  return panel.baseUrl.replace('http://', 'ws://') + path
+}
+
+function once<T = void>(client: WsClient, event: string): Promise<T> {
+  return new Promise(resolve => client.once(event, ((...args: AnyType[]) => resolve(args[0])) as AnyType))
+}
+
+function postLogin(
+  panel: MockPanel,
+  body = 'username=admin&password=secret'
+): Promise<{ status: number; json: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      `${panel.baseUrl}/api/admin/token`,
+      { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' } },
+      res => {
+        const chunks: Buffer[] = []
+        res.on('data', chunk => chunks.push(chunk))
+        res.on('end', () => {
+          resolve({ status: res.statusCode!, json: JSON.parse(Buffer.concat(chunks).toString('utf8')) })
+        })
+      }
+    )
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
+describe('mock-panel', () => {
+  let panel: MockPanel
+
+  beforeEach(async () => {
+    panel = await startMockPanel()
+  })
+
+  afterEach(async () => {
+    await panel.stop()
+  })
+
+  describe('login endpoint', () => {
+    it('accepts a login and returns the default token', async () => {
+      const { status, json } = await postLogin(panel)
+
+      expect(status).toBe(200)
+      expect(json).toEqual({ access_token: 'mock-access-token', token_type: 'bearer' })
+      expect(panel.logins).toEqual([{ username: 'admin', password: 'secret' }])
+    })
+
+    it('returns a configured token', async () => {
+      panel.setLogin({ mode: 'ok', token: 'custom-token' })
+
+      const { json } = await postLogin(panel)
+
+      expect(json).toMatchObject({ access_token: 'custom-token' })
+    })
+
+    it('fails with the default status', async () => {
+      panel.setLogin({ mode: 'fail' })
+
+      const { status } = await postLogin(panel)
+
+      expect(status).toBe(401)
+    })
+
+    it('fails with a configured status', async () => {
+      panel.setLogin({ mode: 'fail', status: 500 })
+
+      const { status } = await postLogin(panel)
+
+      expect(status).toBe(500)
+    })
+
+    it('stalls the response until releaseLogin() is called', async () => {
+      panel.setLogin({ mode: 'stall' })
+
+      let resolved = false
+      const pending = postLogin(panel).then(result => {
+        resolved = true
+        return result
+      })
+
+      await new Promise(resolve => setTimeout(resolve, 30))
+      expect(resolved).toBe(false)
+
+      panel.releaseLogin()
+      const { status, json } = await pending
+
+      expect(resolved).toBe(true)
+      expect(status).toBe(200)
+      expect(json).toMatchObject({ access_token: 'mock-access-token' })
+    })
+
+    it('throws when releaseLogin() is called with nothing pending', () => {
+      expect(() => panel.releaseLogin()).toThrow(/no stalled login request pending/)
+    })
+
+    it('returns 404 for a GET request', async () => {
+      const status = await new Promise<number>((resolve, reject) => {
+        http.get(panel.baseUrl, res => resolve(res.statusCode!)).on('error', reject)
+      })
+      expect(status).toBe(404)
+    })
+
+    it('returns 404 for a POST to an unrelated path', async () => {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = http.request(`${panel.baseUrl}/unknown`, { method: 'POST' }, res => resolve(res.statusCode!))
+        req.on('error', reject)
+        req.end()
+      })
+      expect(status).toBe(404)
+    })
+  })
+
+  describe('handshake', () => {
+    it('accepts a connection and records the handshake', async () => {
+      const client = new WsClient(wsUrl(panel, '/api/core/logs?token=abc&interval=5'))
+      await once(client, 'open')
+
+      expect(panel.handshakes).toEqual([
+        expect.objectContaining({ pathname: '/api/core/logs', token: 'abc', interval: '5' }),
+      ])
+      expect(panel.sockets.size).toBe(1)
+
+      client.terminate()
+    })
+
+    it('delivers broadcast messages to open sockets', async () => {
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      await once(client, 'open')
+
+      const messageArrived = once<Buffer>(client, 'message')
+      panel.broadcast('hello from panel')
+      const data = await messageArrived
+
+      expect(data.toString('utf8')).toBe('hello from panel')
+      client.terminate()
+    })
+
+    it('rejects the handshake with the default status before accept()', async () => {
+      panel.setHandshake({ mode: 'reject' })
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+
+      const err = await once<Error>(client, 'error')
+
+      expect(err.message).toMatch(/403/)
+      expect(panel.sockets.size).toBe(0)
+    })
+
+    it('rejects the handshake with a configured status', async () => {
+      panel.setHandshake({ mode: 'reject', status: 401 })
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+
+      const err = await once<Error>(client, 'error')
+
+      expect(err.message).toMatch(/401/)
+    })
+
+    it('hangs the handshake until stop() tears it down', async () => {
+      panel.setHandshake({ mode: 'hang' })
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+
+      let settled = false
+      client.once('open', () => (settled = true))
+      client.once('error', () => (settled = true))
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(settled).toBe(false)
+
+      client.terminate()
+    })
+
+    it('accepts after a delay', async () => {
+      panel.setHandshake({ mode: 'delay', ms: 40 })
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+
+      const start = Date.now()
+      await once(client, 'open')
+
+      expect(Date.now() - start).toBeGreaterThanOrEqual(35)
+      client.terminate()
+    })
+
+    it('drops connections abruptly with dropAll()', async () => {
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      await once(client, 'open')
+
+      const closed = once(client, 'close')
+      panel.dropAll()
+      await closed
+    })
+
+    it('closes connections cleanly with closeAll()', async () => {
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      await once(client, 'open')
+
+      const closed = new Promise<[number, Buffer]>(resolve => {
+        client.once('close', (code: number, reason: Buffer) => resolve([code, reason]))
+      })
+      panel.closeAll(1000, 'bye')
+      const [code, reason] = await closed
+
+      expect(code).toBe(1000)
+      expect(reason.toString('utf8')).toBe('bye')
+    })
+  })
+
+  describe('waiting helpers', () => {
+    it('waitForConnection resolves once a socket is open', async () => {
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const socket = await panel.waitForConnection()
+
+      expect(socket.readyState).toBe(socket.OPEN)
+      client.terminate()
+    })
+
+    it('waitForConnections resolves once enough sockets have connected', async () => {
+      const first = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const second = new WsClient(wsUrl(panel, '/api/core/logs'))
+
+      const sockets = await panel.waitForConnections(2)
+
+      expect(sockets).toHaveLength(2)
+      first.terminate()
+      second.terminate()
+    })
+
+    it('waitForConnections rejects once the timeout elapses', async () => {
+      panel.setHandshake({ mode: 'hang' })
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      client.on('error', () => {})
+
+      await expect(panel.waitForConnections(1, 40)).rejects.toThrow(/waitForConnections/)
+      client.terminate()
+    })
+
+    it('waitForHandshakes resolves once enough handshakes have been recorded', async () => {
+      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const handshakes = await panel.waitForHandshakes(1)
+
+      expect(handshakes).toHaveLength(1)
+      client.terminate()
+    })
+  })
+
+  it('stop() is idempotent', async () => {
+    await panel.stop()
+    await panel.stop()
+  })
+})

--- a/packages/sdk/src/testing/mock-panel.ts
+++ b/packages/sdk/src/testing/mock-panel.ts
@@ -1,0 +1,268 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import http from 'node:http'
+import type { Socket } from 'node:net'
+
+import type { WebSocket as WsSocket } from 'ws'
+import { WebSocketServer } from 'ws'
+
+/** One recorded WebSocket handshake request against the mock panel. */
+export interface RecordedHandshake {
+  pathname: string
+  token: string | null
+  interval: string | null
+  headers: IncomingMessage['headers']
+}
+
+/** One recorded `POST /api/admin/token` request against the mock panel. */
+export interface RecordedLogin {
+  username: string
+  password: string
+}
+
+export type HandshakePolicy =
+  | { mode: 'accept' }
+  /** Rejects before `websocket.accept()`, mirroring how uvicorn collapses 4401/4403/4400 into one HTTP status. */
+  | { mode: 'reject'; status?: number }
+  /** Accepts after a delay — simulates a slow TLS/proxy layer in front of the panel. */
+  | { mode: 'delay'; ms: number }
+  /** Never responds to the upgrade — simulates a connection stuck in `CONNECTING`. */
+  | { mode: 'hang' }
+
+export type LoginPolicy =
+  | { mode: 'ok'; token?: string }
+  | { mode: 'fail'; status?: number }
+  /** Holds the response open until {@link MockPanel.releaseLogin} is called. */
+  | { mode: 'stall' }
+
+const DEFAULT_TOKEN = 'mock-access-token'
+const DEFAULT_WAIT_TIMEOUT_MS = 2_000
+const POLL_INTERVAL_MS = 10
+
+/**
+ * A disposable fake Marzban panel for WS module tests: one `http.Server`
+ * serving `POST /api/admin/token` and handling every other request as a
+ * WebSocket upgrade — structurally mirroring the real panel, where uvicorn
+ * authorizes a WS connection before `websocket.accept()` on the same origin.
+ *
+ * This is not a mock of `WebSocketClient` or `LogsStream` — it's a real
+ * socket on loopback, so tests built on it get real event-loop timing
+ * instead of the synchronous fake in `logs-stream.test.ts`. It has no
+ * knowledge of `LogsStream`'s behavior; policies are named after what a
+ * network/panel can actually do (accept, reject, delay, hang, drop).
+ */
+export interface MockPanel {
+  /** `http://127.0.0.1:<port>` — pass as `baseUrl` to `createMarzbanSDK`/`configurationUrlWs`. */
+  readonly baseUrl: string
+  readonly handshakes: readonly RecordedHandshake[]
+  readonly logins: readonly RecordedLogin[]
+  /** Currently open server-side sockets (closed ones are removed automatically). */
+  readonly sockets: ReadonlySet<WsSocket>
+  /** Applies to every upgrade from here on, including ones already in flight. */
+  setHandshake(policy: HandshakePolicy): void
+  setLogin(policy: LoginPolicy): void
+  /** Resolves the oldest pending 'stall' login request. Throws if none is pending. */
+  releaseLogin(): void
+  /** Resolves once at least `count` connections have ever been accepted (open or since closed). */
+  waitForConnections(count: number, timeoutMs?: number): Promise<WsSocket[]>
+  waitForConnection(timeoutMs?: number): Promise<WsSocket>
+  waitForHandshakes(count: number, timeoutMs?: number): Promise<RecordedHandshake[]>
+  /** Sends `data` to every currently open socket. */
+  broadcast(data: string): void
+  /** Abruptly terminates every currently open socket — a transport-level disconnect, not a protocol close. */
+  dropAll(): void
+  /** Closes every currently open socket with a normal WebSocket close frame. */
+  closeAll(code?: number, reason?: string): void
+  /** Tears down hanging upgrades, live sockets, and the server. Idempotent. */
+  stop(): Promise<void>
+}
+
+export async function startMockPanel(): Promise<MockPanel> {
+  const handshakes: RecordedHandshake[] = []
+  const logins: RecordedLogin[] = []
+  const sockets = new Set<WsSocket>()
+  const connectionLog: WsSocket[] = []
+  const hangingUpgrades = new Set<Socket>()
+  const pendingLoginReleases: Array<() => void> = []
+
+  let handshakePolicy: HandshakePolicy = { mode: 'accept' }
+  let loginPolicy: LoginPolicy = { mode: 'ok' }
+  let stopped = false
+
+  const wss = new WebSocketServer({ noServer: true })
+
+  function handleLogin(req: IncomingMessage, res: ServerResponse): void {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => {
+      const body = new URLSearchParams(Buffer.concat(chunks).toString('utf8'))
+      // Only real callers of this fixture are the SDK's own login flow and
+      // tests that deliberately drive it the same way — both always send
+      // both fields, so a missing field here would be a bug in the caller,
+      // not a case to handle gracefully.
+      logins.push({ username: body.get('username')!, password: body.get('password')! })
+
+      const respond = () => {
+        if (loginPolicy.mode === 'fail') {
+          res.writeHead(loginPolicy.status ?? 401, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ detail: 'mock login failure' }))
+          return
+        }
+        const token = loginPolicy.mode === 'ok' ? (loginPolicy.token ?? DEFAULT_TOKEN) : DEFAULT_TOKEN
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ access_token: token, token_type: 'bearer' }))
+      }
+
+      if (loginPolicy.mode === 'stall') {
+        pendingLoginReleases.push(respond)
+        return
+      }
+      respond()
+    })
+  }
+
+  const server = http.createServer((req, res) => {
+    // Both server callbacks fire only for requests this same process sent
+    // (the SDK's own axios/WebSocket clients), which always set `url` — the
+    // `string | undefined` in IncomingMessage's type is for the CONNECT-method
+    // case, which never occurs here.
+    if (req.method === 'POST' && req.url!.startsWith('/api/admin/token')) {
+      handleLogin(req, res)
+      return
+    }
+    res.writeHead(404)
+    res.end()
+  })
+
+  server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
+    const url = new URL(req.url!, 'http://mock-panel')
+    handshakes.push({
+      pathname: url.pathname,
+      token: url.searchParams.get('token'),
+      interval: url.searchParams.get('interval'),
+      headers: req.headers,
+    })
+
+    const policy = handshakePolicy
+
+    if (policy.mode === 'hang') {
+      hangingUpgrades.add(socket)
+      socket.once('close', () => hangingUpgrades.delete(socket))
+      return
+    }
+
+    if (policy.mode === 'reject') {
+      socket.end(`HTTP/1.1 ${policy.status ?? 403} Forbidden\r\n\r\n`)
+      return
+    }
+
+    const accept = () => {
+      wss.handleUpgrade(req, socket, head, ws => {
+        sockets.add(ws)
+        connectionLog.push(ws)
+        ws.once('close', () => sockets.delete(ws))
+        wss.emit('connection', ws, req)
+      })
+    }
+
+    if (policy.mode === 'delay') {
+      setTimeout(accept, policy.ms)
+      return
+    }
+
+    accept()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  const address = server.address()
+  // Binding to port 0 on an explicit IPv4 host always yields an AddressInfo —
+  // this only guards against a shape that http.Server's own types allow.
+  /* istanbul ignore next */
+  if (!address || typeof address === 'string') {
+    throw new Error('mock panel failed to bind to a TCP port')
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`
+
+  async function waitFor<T>(check: () => T | undefined, timeoutMs: number, message: string): Promise<T> {
+    const deadline = Date.now() + timeoutMs
+    for (;;) {
+      const value = check()
+      if (value !== undefined) return value
+      if (Date.now() >= deadline) throw new Error(message)
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+  }
+
+  function waitForConnections(count: number, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS): Promise<WsSocket[]> {
+    return waitFor(
+      () => (connectionLog.length >= count ? connectionLog.slice(0, count) : undefined),
+      timeoutMs,
+      `waitForConnections: expected ${count}, got ${connectionLog.length}`
+    )
+  }
+
+  return {
+    baseUrl,
+    handshakes,
+    logins,
+    sockets,
+
+    setHandshake(policy) {
+      handshakePolicy = policy
+    },
+
+    setLogin(policy) {
+      loginPolicy = policy
+    },
+
+    releaseLogin() {
+      const release = pendingLoginReleases.shift()
+      if (!release) {
+        throw new Error('releaseLogin() called with no stalled login request pending')
+      }
+      release()
+    },
+
+    waitForConnections,
+
+    waitForConnection(timeoutMs = DEFAULT_WAIT_TIMEOUT_MS) {
+      return waitForConnections(1, timeoutMs).then(([socket]) => socket!)
+    },
+
+    waitForHandshakes(count, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS) {
+      return waitFor(
+        () => (handshakes.length >= count ? handshakes.slice(0, count) : undefined),
+        timeoutMs,
+        `waitForHandshakes: expected ${count}, got ${handshakes.length}`
+      )
+    },
+
+    broadcast(data) {
+      sockets.forEach(ws => ws.send(data))
+    },
+
+    dropAll() {
+      sockets.forEach(ws => ws.terminate())
+    },
+
+    closeAll(code, reason) {
+      sockets.forEach(ws => ws.close(code, reason))
+    },
+
+    async stop() {
+      if (stopped) return
+      stopped = true
+
+      hangingUpgrades.forEach(socket => socket.destroy())
+      hangingUpgrades.clear()
+      sockets.forEach(ws => ws.terminate())
+      sockets.clear()
+
+      await new Promise<void>(resolve => wss.close(() => resolve()))
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    },
+  }
+}

--- a/packages/sdk/src/testing/transports.test.ts
+++ b/packages/sdk/src/testing/transports.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { selectWsTransport, WS_TRANSPORTS } from './transports'
+
+describe('selectWsTransport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('lists the native and ws-package transports', () => {
+    expect(WS_TRANSPORTS).toEqual(['native', 'ws-package'])
+  })
+
+  it('leaves the native global WebSocket untouched', () => {
+    const native = globalThis.WebSocket
+
+    selectWsTransport('native')
+
+    expect(globalThis.WebSocket).toBe(native)
+  })
+
+  it('removes the global WebSocket to force the ws-package transport', () => {
+    selectWsTransport('ws-package')
+
+    expect(globalThis.WebSocket).toBeUndefined()
+  })
+})

--- a/packages/sdk/src/testing/transports.ts
+++ b/packages/sdk/src/testing/transports.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+
+export type WsTransportName = 'native' | 'ws-package'
+
+/**
+ * WS-module tests need to prove behavior holds on both transports
+ * `WebSocketClient.create` can pick (see `core/ws/client/websocket-client.ts`):
+ * the native global `WebSocket` (browsers, Deno, Bun, Node 21+) and the `ws`
+ * package fallback (older Node, or a configured `httpsAgent`). Vitest's
+ * `environment: 'node'` always has a native `WebSocket`, so exercising the
+ * `ws`-package path requires removing it for the duration of a test.
+ */
+export const WS_TRANSPORTS: readonly WsTransportName[] = ['native', 'ws-package']
+
+/**
+ * Selects which transport `WebSocketClient.create` resolves to for the
+ * duration of the current test. Call inside a `beforeEach`/test body;
+ * `vi.unstubAllGlobals()` in an `afterEach` restores the native global.
+ */
+export function selectWsTransport(name: WsTransportName): void {
+  if (name === 'ws-package') {
+    vi.stubGlobal('WebSocket', undefined)
+  }
+}

--- a/packages/sdk/test/integration/logs.integration.test.ts
+++ b/packages/sdk/test/integration/logs.integration.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { MarzbanSDK } from '../../src/index'
+import { createTestSdk } from './helpers/client'
+
+// The only smoke coverage of the WS module against a real panel — the
+// detailed timing/race scenarios (reconnect, connect-timeout, shutdown
+// races) live on the `src/testing/mock-panel.ts` fixture instead (see
+// issue #85); a real panel gives no way to force those deterministically.
+describe('logs integration (WebSocket log streaming)', () => {
+  let sdk: MarzbanSDK
+
+  beforeAll(async () => {
+    sdk = await createTestSdk()
+  })
+
+  afterAll(async () => {
+    await sdk.destroy()
+  })
+
+  it('streams core log lines and closes without invoking onError', async () => {
+    const messages: unknown[] = []
+    const errors: unknown[] = []
+
+    const close = await sdk.logs.connectByCore({
+      onMessage: data => messages.push(data),
+      onError: err => errors.push(err),
+    })
+
+    // restartCore reliably produces log output on a freshly-subscribed
+    // stream — the panel logs its own startup sequence.
+    await sdk.core.restartCore()
+
+    await expect.poll(() => messages.length, { timeout: 15_000, interval: 250 }).toBeGreaterThan(0)
+
+    close()
+
+    expect(errors).toEqual([])
+  })
+
+  it('rejects a handshake with interval > 10 before the panel accepts the socket', async () => {
+    const errors: unknown[] = []
+
+    await sdk.logs.connectByCore({
+      interval: 11,
+      onMessage: () => {},
+      onError: err => errors.push(err),
+    })
+
+    // Marzban authorizes before websocket.accept() and rejects interval > 10
+    // with a close uvicorn collapses into a generic HTTP 403 (see
+    // docs/marzban-quirks.md) — the SDK retries it as an auth failure and
+    // eventually gives up, calling onError once the retry budget is spent.
+    await expect.poll(() => errors.length, { timeout: 15_000, interval: 250 }).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `packages/sdk/src/testing/mock-panel.ts`: a disposable fake panel (real `http.Server` + `ws.Server`) for WS-module tests — configurable handshake policy (accept/reject/delay/hang) and login policy (ok/fail/stall), plus wait/broadcast/drop/close helpers. Real socket timing instead of `logs-stream.test.ts`'s synchronous fake, which structurally can't reproduce the timing bugs tracked in #86/#87/#88.
- Adds `packages/sdk/src/testing/transports.ts` to force the `ws`-package transport for a test, so WS behavior can be asserted on both transports `WebSocketClient.create` can resolve to.
- Adds `logs-stream.server.test.ts` (full `createMarzbanSDK` → real socket) and self-tests for the fixture itself — 100% coverage maintained.
- Adds a minimal WS integration smoke test (`test/integration/logs.integration.test.ts`) against a live local panel — the one SDK module that had none.
- No changes to `src/core/ws` runtime code — pure test infrastructure, as scoped by #85.
- Docs: `docs/testing.md` (new "WS module" section), `docs/marzban-quirks.md` (403-collapse-on-handshake quirk), `packages/sdk/ARCHITECTURE.md` (directory map entry for `src/testing/`).

Closes #85.

## Test plan

- [x] `pnpm --filter marzban-sdk test:coverage` — 672 tests, 100% statements/branches/functions/lines
- [x] `pnpm --filter marzban-sdk types:check`, `pnpm lint`, `pnpm format:check`
- [x] `pnpm --filter marzban-sdk build` — confirmed `src/testing/**` is not bundled into `dist`
- [x] WS-related tests repeated 5x locally with no flakiness
- [x] `pnpm local:up && pnpm --filter marzban-sdk test:integration` — full integration suite (14 files, 80 tests) passes, including the new `logs.integration.test.ts`, repeated 3x