### PR TITLE
Fix flaky WS mock-panel test and duplicate CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,12 @@ on:
   pull_request:
     branches: [main, dev]
   push:
-    branches: [main, dev]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,11 +1,15 @@
 name: Integration
 
 on:
-  push:
-    branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  push:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/docs/adr/0012-gate-dev-with-ci.md
+++ b/docs/adr/0012-gate-dev-with-ci.md
@@ -22,10 +22,11 @@ caused it.
 
 ## Decision
 
-- Extend `ci.yml` and `integration.yml` triggers to `dev` in addition to
-  `main`, so every PR into `dev` gets the same `lint` / `types:check` /
-  `test` / `build` / `format:check` run and the same integration-suite
-  signal that `main` already had.
+- Extend `ci.yml` and `integration.yml` `pull_request` triggers to `dev` in
+  addition to `main`, so every PR into `dev` gets the same `lint` /
+  `types:check` / `test` / `build` / `format:check` run and the same
+  integration-suite signal that `main` already had. The `push` trigger stays
+  on `main` only — see the note below on why `dev` isn't also a push branch.
 - Add GitHub branch protection to both `main` and `dev`, requiring the `ci`
   status check to pass (and the branch to be up to date) before a PR can
   merge. `integration` stays informational on both branches, same as it
@@ -36,6 +37,15 @@ caused it.
 - `CONTRIBUTING.md` is updated to describe the actual flow (PR into `dev`,
   `dev` merges into `main` periodically) instead of the stale "PR against
   `main`" instruction.
+- `push` stays scoped to `main` on both workflows — it is not added for
+  `dev`. `dev` is protected the same way `main` is (direct pushes are
+  blocked), so its only path in is a PR, which the `pull_request` trigger
+  already covers. Adding `push: [main, dev]` as well would double-run every
+  `dev`-bound PR (once as `pull_request`, once as `push` on the PR's head
+  branch, since that branch is also listed) — both runs get the same
+  `Required` status, so a flake in either one blocks the merge even when
+  the other is green. A `concurrency` group per workflow additionally
+  cancels a superseded run when the PR branch is pushed again quickly.
 
 ## Consequences
 

--- a/packages/sdk/src/testing/mock-panel.test.ts
+++ b/packages/sdk/src/testing/mock-panel.test.ts
@@ -16,6 +16,20 @@ function once<T = void>(client: WsClient, event: string): Promise<T> {
   return new Promise(resolve => client.once(event, ((...args: AnyType[]) => resolve(args[0])) as AnyType))
 }
 
+// `ws` throws an uncaught exception when `terminate()`/`close()` is called
+// while the socket is still CONNECTING (see `abortHandshake` in
+// `ws/lib/websocket.js`) unless something is listening for `error`. Every
+// client in this file goes through here so afterEach can always clean up,
+// even mid-handshake, without crashing the run.
+let clients: WsClient[] = []
+
+function connect(panel: MockPanel, path: string): WsClient {
+  const client = new WsClient(wsUrl(panel, path))
+  client.on('error', () => {})
+  clients.push(client)
+  return client
+}
+
 function postLogin(
   panel: MockPanel,
   body = 'username=admin&password=secret'
@@ -45,6 +59,8 @@ describe('mock-panel', () => {
   })
 
   afterEach(async () => {
+    clients.forEach(client => client.terminate())
+    clients = []
     await panel.stop()
   })
 
@@ -124,19 +140,17 @@ describe('mock-panel', () => {
 
   describe('handshake', () => {
     it('accepts a connection and records the handshake', async () => {
-      const client = new WsClient(wsUrl(panel, '/api/core/logs?token=abc&interval=5'))
+      const client = connect(panel, '/api/core/logs?token=abc&interval=5')
       await once(client, 'open')
 
       expect(panel.handshakes).toEqual([
         expect.objectContaining({ pathname: '/api/core/logs', token: 'abc', interval: '5' }),
       ])
       expect(panel.sockets.size).toBe(1)
-
-      client.terminate()
     })
 
     it('delivers broadcast messages to open sockets', async () => {
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
       await once(client, 'open')
 
       const messageArrived = once<Buffer>(client, 'message')
@@ -144,12 +158,11 @@ describe('mock-panel', () => {
       const data = await messageArrived
 
       expect(data.toString('utf8')).toBe('hello from panel')
-      client.terminate()
     })
 
     it('rejects the handshake with the default status before accept()', async () => {
       panel.setHandshake({ mode: 'reject' })
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
 
       const err = await once<Error>(client, 'error')
 
@@ -159,7 +172,7 @@ describe('mock-panel', () => {
 
     it('rejects the handshake with a configured status', async () => {
       panel.setHandshake({ mode: 'reject', status: 401 })
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
 
       const err = await once<Error>(client, 'error')
 
@@ -168,7 +181,7 @@ describe('mock-panel', () => {
 
     it('hangs the handshake until stop() tears it down', async () => {
       panel.setHandshake({ mode: 'hang' })
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
 
       let settled = false
       client.once('open', () => (settled = true))
@@ -176,23 +189,20 @@ describe('mock-panel', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50))
       expect(settled).toBe(false)
-
-      client.terminate()
     })
 
     it('accepts after a delay', async () => {
       panel.setHandshake({ mode: 'delay', ms: 40 })
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
 
       const start = Date.now()
       await once(client, 'open')
 
       expect(Date.now() - start).toBeGreaterThanOrEqual(35)
-      client.terminate()
     })
 
     it('drops connections abruptly with dropAll()', async () => {
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
       await once(client, 'open')
 
       const closed = once(client, 'close')
@@ -201,7 +211,7 @@ describe('mock-panel', () => {
     })
 
     it('closes connections cleanly with closeAll()', async () => {
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const client = connect(panel, '/api/core/logs')
       await once(client, 'open')
 
       const closed = new Promise<[number, Buffer]>(resolve => {
@@ -217,41 +227,35 @@ describe('mock-panel', () => {
 
   describe('waiting helpers', () => {
     it('waitForConnection resolves once a socket is open', async () => {
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      connect(panel, '/api/core/logs')
       const socket = await panel.waitForConnection()
 
       expect(socket.readyState).toBe(socket.OPEN)
-      client.terminate()
     })
 
     it('waitForConnections resolves once enough sockets have connected', async () => {
-      const first = new WsClient(wsUrl(panel, '/api/core/logs'))
-      const second = new WsClient(wsUrl(panel, '/api/core/logs'))
+      const first = connect(panel, '/api/core/logs')
+      const second = connect(panel, '/api/core/logs')
       const opened = Promise.all([once(first, 'open'), once(second, 'open')])
 
       const sockets = await panel.waitForConnections(2)
       await opened
 
       expect(sockets).toHaveLength(2)
-      first.terminate()
-      second.terminate()
     })
 
     it('waitForConnections rejects once the timeout elapses', async () => {
       panel.setHandshake({ mode: 'hang' })
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
-      client.on('error', () => {})
+      connect(panel, '/api/core/logs')
 
       await expect(panel.waitForConnections(1, 40)).rejects.toThrow(/waitForConnections/)
-      client.terminate()
     })
 
     it('waitForHandshakes resolves once enough handshakes have been recorded', async () => {
-      const client = new WsClient(wsUrl(panel, '/api/core/logs'))
+      connect(panel, '/api/core/logs')
       const handshakes = await panel.waitForHandshakes(1)
 
       expect(handshakes).toHaveLength(1)
-      client.terminate()
     })
   })
 


### PR DESCRIPTION
## Summary
- `mock-panel.test.ts`: route every WS client through a `connect()` helper with a no-op `error` listener, cleaned up centrally in `afterEach`. Fixes the intermittent `WebSocket was closed before the connection was established` uncaught exception that was failing `CI / ci (push)` on PR #96.
- `ci.yml` / `integration.yml`: `push` now targets `main` only (was `[main, dev]`), plus a `concurrency` group per workflow. A PR from `dev` into `main` was double-running every check — once as `pull_request`, once as `push` on `dev` — and both carried the `Required` status, so a flake in either one blocked the merge even when the other was green.
- `docs/adr/0012-gate-dev-with-ci.md`: documents why `push` stays scoped to `main`.

## Test plan
- [x] `npx vitest run src/testing/mock-panel.test.ts` — 21/21, 5x in a row
- [x] Same test with `POLL_INTERVAL_MS` temporarily forced to `0` (worst-case race) — 5x in a row, no uncaught exception
- [x] Full SDK suite: `pnpm lint && pnpm types:check && pnpm test` — 672/672
- [x] `pnpm format:check`
- [x] YAML validated for both workflow files