### PR TITLE
fix(sdk): attach WebSocket listeners in the same tick the socket is created

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -77,11 +77,21 @@ pnpm --filter marzban-sdk test:coverage
 
 `core/ws` is the one module whose unit tests don't mock the transport with
 `vi.mock` (see "Network isolation" below) — `logs-stream.test.ts` mocks
-`WebSocketClient.create` itself with a synchronous fake instead, which
-cannot reproduce timing bugs that only show up with a real socket (a
-microtask gap between socket construction and listener attachment, an
+`WebSocketClient.resolve` itself with a synchronous fake instead, which
+cannot reproduce timing bugs that only show up with a real socket (an
 unsolicited `close`, a shutdown racing a reconnect). `packages/sdk/src/testing/`
-fixes that gap with a real `ws.Server` on loopback:
+fixes that gap with a real `ws.Server` on loopback.
+
+`BaseWebSocketClient` itself used to have a microtask gap between socket
+construction and listener attachment — `createWebSocket()` was `async`, so
+`init()` only attached `on()` handlers after at least one `await`, and a
+connection that failed inside that window dispatched `error`/`close` to
+nobody ([issue #86](https://github.com/Ilmar7786/marzban-sdk/issues/86)).
+Fixed by making `createWebSocket()` synchronous and buffering `on()`/`close()`
+calls made before `init()`, so listeners attach in the same tick the socket
+is constructed. `logs-stream.server.test.ts` (below) pins the regression —
+it needs a real socket, since a synchronous fake can't reproduce a race that
+only exists because of real event-loop timing.
 
 - [`mock-panel.ts`](../packages/sdk/src/testing/mock-panel.ts) — one
   `http.Server` standing in for the panel: serves `POST /api/admin/token`
@@ -102,12 +112,15 @@ fixes that gap with a real `ws.Server` on loopback:
   itself. It isn't exported from `src/index.ts`, so it never reaches the
   published package (`tsup`'s only entry is `index.ts`; `files: ["dist"]`
   in `package.json` ships only the build output regardless).
-- `logs-stream.server.test.ts` (next to `logs-stream.test.ts`) is where new
-  WS timing/lifecycle tests belong, built on this fixture instead of a
-  hand-rolled fake. `logs-stream.test.ts` itself stays — it still pins
-  `LogsStream`'s branch behavior efficiently — until it's replaced outright
-  once a public-API change lands (tracked alongside the reconnect rework in
-  [issue #88](https://github.com/Ilmar7786/marzban-sdk/issues/88)).
+- `logs-stream.server.test.ts` (next to `logs-stream.test.ts`) is where WS
+  timing/lifecycle tests belong, built on this fixture instead of a
+  hand-rolled fake — including #86's own regression scenarios (a rejected
+  handshake, a panel that goes unreachable after login) that assert
+  `onError` fires and `activeConnections` ends up empty, on both transports
+  (`describe.each(WS_TRANSPORTS)`). `logs-stream.test.ts` itself stays — it
+  still pins `LogsStream`'s branch behavior efficiently — until it's
+  replaced outright once a public-API change lands (tracked alongside the
+  reconnect rework in [issue #88](https://github.com/Ilmar7786/marzban-sdk/issues/88)).
 
 Reconnect, connect-timeout, and shutdown-race scenarios are exercised on
 this fixture as those behaviors are implemented — see

--- a/packages/sdk/src/core/ws/client/base-websocket-client.test.ts
+++ b/packages/sdk/src/core/ws/client/base-websocket-client.test.ts
@@ -1,18 +1,52 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { BaseWebSocketClient } from './base-websocket-client'
+import type { AnyType } from '@/common'
 
-class FakeSocket {
-  public readyState = 5
-  public addEventListener = vi.fn()
-  public send = vi.fn()
-  public close = vi.fn()
+import { BaseWebSocketClient, type WebSocketClientOptions, type WebSocketLike } from './base-websocket-client'
+
+class FakeSocket implements WebSocketLike {
+  readyState = 5
+  send = vi.fn()
+  close = vi.fn()
+
+  private listeners = new Map<string, Set<(event: AnyType) => void>>()
+
+  constructor(dispatchOnConstruct?: { type: string; event: AnyType }) {
+    if (dispatchOnConstruct) {
+      // Real transports never dispatch synchronously from their own
+      // constructor — networking is inherently async — but they dispatch as
+      // early as the very next microtask. That's exactly what a listener
+      // attached after an `await` between construction and registration
+      // would miss (see issue #86).
+      queueMicrotask(() => this.dispatch(dispatchOnConstruct.type, dispatchOnConstruct.event))
+    }
+  }
+
+  addEventListener(type: string, listener: (event: AnyType) => void): void {
+    const listenersForType = this.listeners.get(type) ?? new Set()
+    listenersForType.add(listener)
+    this.listeners.set(type, listenersForType)
+  }
+
+  private dispatch(type: string, event: AnyType): void {
+    this.listeners.get(type)?.forEach(listener => listener(event))
+  }
 }
 
 class TestWebSocketClient extends BaseWebSocketClient {
-  private socketInstance = new FakeSocket()
+  private socketInstance?: FakeSocket
 
-  protected async createWebSocket() {
+  constructor(
+    url: string,
+    protocols?: string | string[],
+    options?: WebSocketClientOptions,
+    private readonly dispatchOnConstruct?: { type: string; event: AnyType }
+  ) {
+    super(url, protocols, options)
+  }
+
+  protected createWebSocket(): WebSocketLike {
+    this.socketInstance = new FakeSocket(this.dispatchOnConstruct)
     return this.socketInstance
   }
 
@@ -25,28 +59,76 @@ class TestWebSocketClient extends BaseWebSocketClient {
   }
 }
 
-describe('BaseWebSocketClient', () => {
-  it('initializes socket via createWebSocket and proxies methods', async () => {
-    const client = new TestWebSocketClient('wss://example.com', ['proto'])
+class PrepareOrderWebSocketClient extends BaseWebSocketClient {
+  calls: string[] = []
 
-    // Accessing readyState before init should throw because socket is not set yet.
-    expect(() => client.readyState).toThrow()
+  protected async prepare(): Promise<void> {
+    this.calls.push('prepare')
+  }
+
+  protected createWebSocket(): WebSocketLike {
+    this.calls.push('createWebSocket')
+    return new FakeSocket()
+  }
+}
+
+describe('BaseWebSocketClient', () => {
+  it('throws when send/readyState is accessed before init()', () => {
+    const client = new TestWebSocketClient('wss://example.com')
+
+    expect(() => client.readyState).toThrow(TypeError)
+    expect(() => client.send('hello')).toThrow(TypeError)
+  })
+
+  it('awaits prepare() before constructing the socket', async () => {
+    const client = new PrepareOrderWebSocketClient('wss://example.com')
 
     await client.init()
 
-    // `on` should call addEventListener with typed args
-    const listener = vi.fn()
-    client.on('open', listener)
-    expect(client.getSocket().addEventListener).toHaveBeenCalledWith('open', listener)
+    expect(client.calls).toEqual(['prepare', 'createWebSocket'])
+  })
 
-    // send/close should forward to the underlying socket
-    client.send('hello')
-    expect(client.getSocket().send).toHaveBeenCalledWith('hello')
+  it('delivers an event dispatched right after construction to a listener registered before init()', async () => {
+    const event = { type: 'error' }
+    const client = new TestWebSocketClient('wss://example.com', undefined, undefined, { type: 'error', event })
+    const listener = vi.fn()
+
+    client.on('error', listener)
+    await client.init()
+
+    expect(listener).toHaveBeenCalledWith(event)
+  })
+
+  it('attaches a listener registered after init() directly, without buffering', async () => {
+    const client = new TestWebSocketClient('wss://example.com')
+    await client.init()
+
+    const addEventListener = vi.spyOn(client.getSocket()!, 'addEventListener')
+    const listener = vi.fn()
+    client.on('message', listener)
+
+    expect(addEventListener).toHaveBeenCalledWith('message', listener)
+  })
+
+  it('defers close() called before init() and applies it once the socket exists', async () => {
+    const client = new TestWebSocketClient('wss://example.com')
 
     client.close(1000, 'bye')
-    expect(client.getSocket().close).toHaveBeenCalledWith(1000, 'bye')
+    await client.init()
 
-    // readyState should still be reflected
+    expect(client.getSocket()!.close).toHaveBeenCalledWith(1000, 'bye')
+  })
+
+  it('proxies send/close and reflects readyState once initialized', async () => {
+    const client = new TestWebSocketClient('wss://example.com', ['proto'])
+    await client.init()
+
+    client.send('hello')
+    expect(client.getSocket()!.send).toHaveBeenCalledWith('hello')
+
+    client.close(1000, 'bye')
+    expect(client.getSocket()!.close).toHaveBeenCalledWith(1000, 'bye')
+
     expect(client.readyState).toBe(5)
   })
 

--- a/packages/sdk/src/core/ws/client/base-websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/base-websocket-client.ts
@@ -29,11 +29,16 @@ export interface WebSocketClientOptions {
   agent?: HttpAgentLike
 }
 
+type BufferedListener = { event: keyof WebSocketEventMap; listener: (event: AnyType) => void }
+
 export abstract class BaseWebSocketClient {
-  protected socket!: WebSocketLike
+  protected socket?: WebSocketLike
   protected url: string
   protected protocols?: string | string[]
   protected agent?: HttpAgentLike
+
+  private pendingListeners: BufferedListener[] = []
+  private pendingClose?: { code?: number; reason?: string }
 
   constructor(url: string, protocols?: string | string[], options?: WebSocketClientOptions) {
     this.url = url
@@ -41,25 +46,60 @@ export abstract class BaseWebSocketClient {
     this.agent = options?.agent
   }
 
-  protected abstract createWebSocket(): Promise<WebSocketLike>
+  /** Override to await whatever the transport needs before construction (e.g. a lazy `import`). */
+  protected async prepare(): Promise<void> {}
+
+  /**
+   * Synchronous by contract: `init()` attaches every buffered listener in the
+   * same tick the socket is constructed, so nothing the transport dispatches
+   * immediately (a connection-refused `error`, an instant handshake `close`)
+   * is missed.
+   */
+  protected abstract createWebSocket(): WebSocketLike
 
   async init(): Promise<void> {
-    this.socket = await this.createWebSocket()
+    await this.prepare()
+    this.socket = this.createWebSocket()
+
+    for (const { event, listener } of this.pendingListeners) {
+      this.socket.addEventListener(event, listener)
+    }
+    this.pendingListeners = []
+
+    if (this.pendingClose) {
+      this.socket.close(this.pendingClose.code, this.pendingClose.reason)
+    }
+  }
+
+  private get activeSocket(): WebSocketLike {
+    if (!this.socket) {
+      throw new TypeError('WebSocket is not initialized yet — call init() first')
+    }
+    return this.socket
   }
 
   on<K extends keyof WebSocketEventMap>(event: K, listener: (event: WebSocketEventMap[K]) => void): void {
+    if (!this.socket) {
+      this.pendingListeners.push({ event, listener: listener as (event: AnyType) => void })
+      return
+    }
     this.socket.addEventListener(event, listener as (event: AnyType) => void)
   }
 
   send(data: string | ArrayBuffer | Blob | ArrayBufferView): void {
-    this.socket.send(data)
+    this.activeSocket.send(data)
   }
 
+  /** Before `init()`, closes the socket as soon as it exists instead of throwing. */
   close(code?: number, reason?: string): void {
+    if (!this.socket) {
+      this.pendingClose = { code, reason }
+      return
+    }
     this.socket.close(code, reason)
   }
 
   get readyState(): number {
-    return this.socket.readyState
+    return this.activeSocket.readyState
   }
 }

--- a/packages/sdk/src/core/ws/client/browser-websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/browser-websocket-client.ts
@@ -1,7 +1,7 @@
 import { BaseWebSocketClient, WebSocketLike } from './base-websocket-client'
 
 export class BrowserWebSocketClient extends BaseWebSocketClient {
-  protected async createWebSocket(): Promise<WebSocketLike> {
+  protected createWebSocket(): WebSocketLike {
     return new WebSocket(this.url, this.protocols)
   }
 }

--- a/packages/sdk/src/core/ws/client/node-websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/node-websocket-client.ts
@@ -1,10 +1,19 @@
+import type WsWebSocket from 'ws'
+
 import { AnyType } from '@/common'
 
 import { BaseWebSocketClient, WebSocketLike } from './base-websocket-client'
 
 export class NodeWebSocketClient extends BaseWebSocketClient {
-  protected async createWebSocket(): Promise<WebSocketLike> {
+  private wsConstructor?: typeof WsWebSocket
+
+  protected async prepare(): Promise<void> {
     const { default: NodeWebSocket } = await import('ws')
+    this.wsConstructor = NodeWebSocket
+  }
+
+  protected createWebSocket(): WebSocketLike {
+    const NodeWebSocket = this.wsConstructor!
     // The `ws` socket is EventTarget-compatible (addEventListener/send/close/
     // readyState) but its DOM typings differ, so we adapt it structurally —
     // `agent` (our structural HttpAgentLike, not ws's own Agent type) the

--- a/packages/sdk/src/core/ws/client/websocket-client.test.ts
+++ b/packages/sdk/src/core/ws/client/websocket-client.test.ts
@@ -147,4 +147,21 @@ describe('WebSocketClient', () => {
 
     expect(client.constructor.name).toBe('BrowserWebSocketClient')
   })
+
+  it('resolve() picks the client without connecting it, leaving create() as resolve() + init()', async () => {
+    class FakeWebSocket {
+      public readyState = 1
+      addEventListener = vi.fn()
+    }
+    ;(globalThis as AnyType).WebSocket = FakeWebSocket
+
+    const { WebSocketClient } = await import('./websocket-client')
+    const client = WebSocketClient.resolve('wss://example.com')
+
+    expect(client.constructor.name).toBe('BrowserWebSocketClient')
+    expect(() => client.readyState).toThrow(TypeError)
+
+    await client.init()
+    expect(client.readyState).toBe(1)
+  })
 })

--- a/packages/sdk/src/core/ws/client/websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/websocket-client.ts
@@ -6,7 +6,10 @@ import { NodeWebSocketClient } from './node-websocket-client'
 
 export class WebSocketClient {
   /**
-   * Creates a WebSocket client appropriate for the current runtime.
+   * Picks the WebSocket client appropriate for the current runtime, without
+   * initializing it — callers that need to register listeners before the
+   * socket connects (e.g. `LogsStream`) call `init()` themselves once those
+   * listeners are attached, so nothing dispatched immediately is missed.
    *
    * Prefers the native global `WebSocket` when available — this covers
    * browsers, Web Workers, Deno, Bun, and Node.js 21+. Only older Node.js
@@ -21,18 +24,21 @@ export class WebSocketClient {
    * ignored here — this class has no logger of its own, so callers that want
    * to warn their users do so themselves (see `LogsStream`).
    */
+  static resolve(url: string, protocols?: string | string[], options?: WebSocketClientOptions): BaseWebSocketClient {
+    const needsAgentCapableClient = Boolean(options?.agent) && !isBrowser()
+
+    return needsAgentCapableClient || !hasNativeWebSocket()
+      ? new NodeWebSocketClient(url, protocols, options)
+      : new BrowserWebSocketClient(url, protocols, options)
+  }
+
+  /** {@link resolve} followed by `init()` — for callers with nothing to attach before connecting. */
   static async create(
     url: string,
     protocols?: string | string[],
     options?: WebSocketClientOptions
   ): Promise<BaseWebSocketClient> {
-    const needsAgentCapableClient = Boolean(options?.agent) && !isBrowser()
-
-    const client: BaseWebSocketClient =
-      needsAgentCapableClient || !hasNativeWebSocket()
-        ? new NodeWebSocketClient(url, protocols, options)
-        : new BrowserWebSocketClient(url, protocols, options)
-
+    const client = WebSocketClient.resolve(url, protocols, options)
     await client.init()
     return client
   }

--- a/packages/sdk/src/core/ws/logs-stream.server.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream.server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { AnyType } from '@/common'
 import { createMarzbanSDK, type MarzbanSDK } from '@/core/MarzbanSDK'
 import type { MockPanel } from '@/testing'
 import { selectWsTransport, startMockPanel, WS_TRANSPORTS } from '@/testing'
@@ -7,9 +8,13 @@ import { selectWsTransport, startMockPanel, WS_TRANSPORTS } from '@/testing'
 /**
  * `LogsStream` exercised against the real-socket fixture from `src/testing/`
  * instead of the synchronous fake in `logs-stream.test.ts` (see that file's
- * header comment). Only asserts invariants expected to survive #86-#88's
- * reconnect rework — no reconnect/retry/timeout scenarios here, those land
- * with the rework that implements them.
+ * header comment). Besides the invariants expected to survive #86-#88's
+ * reconnect rework, this also carries #86's own regression coverage — a
+ * connect that fails (rejected handshake, unreachable host) before it ever
+ * opens must still reach `onError` and must not leave a dead entry in
+ * `activeConnections`, which requires the real event-loop timing this
+ * fixture provides. No reconnect/retry/timeout scenarios beyond that here —
+ * those land with the #88 rework.
  */
 describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName => {
   let panel: MockPanel
@@ -97,5 +102,41 @@ describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName =
 
     const handshakes = await panel.waitForHandshakes(2)
     expect(handshakes[1]?.token).toBe('second-token')
+  })
+
+  it('calls onError and leaves no tracked connection when the handshake is rejected (issue #86)', async () => {
+    const instance = await connectSdk()
+    panel.setHandshake({ mode: 'reject', status: 403 })
+
+    const onError = vi.fn()
+    await instance.logs.connectByCore({ onMessage: () => {}, onError })
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled())
+    expect((instance.logs as AnyType).activeConnections.size).toBe(0)
+  })
+
+  it('calls onError and leaves no tracked connection when the panel is unreachable (issue #86)', async () => {
+    const instance = await connectSdk()
+    // Token is already cached from connectSdk()'s login, so this reaches the
+    // socket construction path without needing the panel to be up.
+    await panel.stop()
+
+    const onError = vi.fn()
+    await instance.logs.connectByCore({ onMessage: () => {}, onError })
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled())
+    expect((instance.logs as AnyType).activeConnections.size).toBe(0)
+  })
+
+  it('untracks the connection once the transport drops mid-stream', async () => {
+    const instance = await connectSdk()
+
+    await instance.logs.connectByCore({ onMessage: () => {} })
+    await panel.waitForConnection()
+    expect((instance.logs as AnyType).activeConnections.size).toBe(1)
+
+    panel.dropAll()
+
+    await vi.waitFor(() => expect((instance.logs as AnyType).activeConnections.size).toBe(0))
   })
 })

--- a/packages/sdk/src/core/ws/logs-stream.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream.test.ts
@@ -18,20 +18,19 @@ import { configurationUrlWs } from './utils'
 
 vi.mock('./client', () => ({
   WebSocketClient: {
-    create: vi.fn(),
+    resolve: vi.fn(),
   },
 }))
 
-const mockCreate = (
+const mockResolve = (
   WebSocketClient as unknown as {
-    create: Mock<
-      (url: string, protocols?: string | string[], options?: WebSocketClientOptions) => Promise<BaseWebSocketClient>
-    >
+    resolve: Mock<(url: string, protocols?: string | string[], options?: WebSocketClientOptions) => BaseWebSocketClient>
   }
-).create
+).resolve
 
 type FakeWebSocketClient = {
   on: (event: string, listener: (payload: AnyType) => AnyType) => void
+  init: ReturnType<typeof vi.fn>
   close: ReturnType<typeof vi.fn>
   trigger: (event: string, payload?: AnyType) => Promise<AnyType> | AnyType
 }
@@ -43,6 +42,7 @@ function createFakeWebSocketClient(): FakeWebSocketClient {
     on(event, listener) {
       handlers.set(event, listener)
     },
+    init: vi.fn().mockResolvedValue(undefined),
     close: vi.fn(() => {
       const handler = handlers.get('close')
       if (handler) {
@@ -68,7 +68,7 @@ describe('LogsStream', () => {
   let logger: AnyType
 
   beforeEach(() => {
-    mockCreate.mockReset()
+    mockResolve.mockReset()
 
     authService = {
       waitForCurrentAuth: vi.fn().mockResolvedValue(undefined),
@@ -86,7 +86,7 @@ describe('LogsStream', () => {
 
   it('sends messages from WebSocket to the provided callback', async () => {
     const wsClient = createFakeWebSocketClient()
-    mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
 
     const stream = new LogsStream({ basePath, authService, logger })
     const onMessage = vi.fn()
@@ -101,7 +101,7 @@ describe('LogsStream', () => {
       interval: 1,
     })
 
-    expect(mockCreate).toHaveBeenCalledWith(expectedUrl, undefined, { agent: undefined })
+    expect(mockResolve).toHaveBeenCalledWith(expectedUrl, undefined, { agent: undefined })
 
     const payload = { foo: 'bar' }
     await wsClient.trigger('message', { data: payload })
@@ -119,9 +119,9 @@ describe('LogsStream', () => {
     const firstWsClient = createFakeWebSocketClient()
     const secondWsClient = createFakeWebSocketClient()
 
-    mockCreate
-      .mockResolvedValueOnce(firstWsClient as unknown as BaseWebSocketClient)
-      .mockResolvedValueOnce(secondWsClient as unknown as BaseWebSocketClient)
+    mockResolve
+      .mockReturnValueOnce(firstWsClient as unknown as BaseWebSocketClient)
+      .mockReturnValueOnce(secondWsClient as unknown as BaseWebSocketClient)
 
     authService.retryAuth.mockImplementation(async () => {
       authService.accessToken = 'refreshed-token'
@@ -146,7 +146,7 @@ describe('LogsStream', () => {
       token: 'refreshed-token',
       interval: 1,
     })
-    expect(mockCreate).toHaveBeenLastCalledWith(expectedUrl, undefined, { agent: undefined })
+    expect(mockResolve).toHaveBeenLastCalledWith(expectedUrl, undefined, { agent: undefined })
 
     // Verify we don't keep around the failing connection.
     expect((stream as AnyType).activeConnections.size).toBe(1)
@@ -154,7 +154,7 @@ describe('LogsStream', () => {
 
   it('calls onError when re-authentication fails during a 403 retry', async () => {
     const wsClient = createFakeWebSocketClient()
-    mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
 
     // Token is present, so the initial connect succeeds; the retry's retryAuth fails.
     authService.retryAuth.mockRejectedValueOnce(new Error('re-auth failed'))
@@ -171,16 +171,16 @@ describe('LogsStream', () => {
     expect(onError).toHaveBeenCalled()
     // The failing connection was removed and no new one was established.
     expect((stream as AnyType).activeConnections.size).toBe(0)
-    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(mockResolve).toHaveBeenCalledTimes(1)
   })
 
   it('calls onError after reaching max retry attempts', async () => {
     const firstWsClient = createFakeWebSocketClient()
     const secondWsClient = createFakeWebSocketClient()
 
-    mockCreate
-      .mockResolvedValueOnce(firstWsClient as unknown as BaseWebSocketClient)
-      .mockResolvedValueOnce(secondWsClient as unknown as BaseWebSocketClient)
+    mockResolve
+      .mockReturnValueOnce(firstWsClient as unknown as BaseWebSocketClient)
+      .mockReturnValueOnce(secondWsClient as unknown as BaseWebSocketClient)
 
     const stream = new LogsStream({ basePath, authService, logger })
 
@@ -204,7 +204,7 @@ describe('LogsStream', () => {
 
   it('re-authenticates when token is missing before connecting', async () => {
     const wsClient = createFakeWebSocketClient()
-    mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
 
     authService.accessToken = ''
     authService.retryAuth.mockImplementation(async () => {
@@ -225,12 +225,12 @@ describe('LogsStream', () => {
       token: 'new-token',
       interval: 1,
     })
-    expect(mockCreate).toHaveBeenCalledWith(expectedUrl, undefined, { agent: undefined })
+    expect(mockResolve).toHaveBeenCalledWith(expectedUrl, undefined, { agent: undefined })
   })
 
   it('forwards non-403 errors through onError and does not reconnect', async () => {
     const wsClient = createFakeWebSocketClient()
-    mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
 
     const stream = new LogsStream({ basePath, authService, logger })
     const onMessage = vi.fn()
@@ -242,13 +242,13 @@ describe('LogsStream', () => {
 
     expect(onError).toHaveBeenCalled()
     // Should not attempt to reconnect.
-    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(mockResolve).toHaveBeenCalledTimes(1)
     expect((stream as AnyType).activeConnections.size).toBe(1)
   })
 
   it('works when onError is not provided and uses default interval', async () => {
     const wsClient = createFakeWebSocketClient()
-    mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
 
     const stream = new LogsStream({ basePath, authService, logger })
     const onMessage = vi.fn()
@@ -262,16 +262,16 @@ describe('LogsStream', () => {
       interval: 1,
     })
 
-    expect(mockCreate).toHaveBeenCalledWith(expectedUrl, undefined, { agent: undefined })
+    expect(mockResolve).toHaveBeenCalledWith(expectedUrl, undefined, { agent: undefined })
 
     await wsClient.trigger('error', { message: 'Network error' })
     // No error handler provided, so no throw and no reconnect.
-    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(mockResolve).toHaveBeenCalledTimes(1)
   })
 
   it('handles error events without a message property', async () => {
     const wsClient = createFakeWebSocketClient()
-    mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
 
     const stream = new LogsStream({ basePath, authService, logger })
     const onMessage = vi.fn()
@@ -282,16 +282,27 @@ describe('LogsStream', () => {
     await wsClient.trigger('error', {})
 
     expect(onError).toHaveBeenCalled()
-    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(mockResolve).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects and leaves no tracked connection when init() fails (issue #86)', async () => {
+    const wsClient = createFakeWebSocketClient()
+    wsClient.init.mockRejectedValueOnce(new Error('connection refused'))
+    mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
+
+    const stream = new LogsStream({ basePath, authService, logger })
+
+    await expect(stream.connectByCore({ onMessage: vi.fn() })).rejects.toThrow('connection refused')
+    expect((stream as AnyType).activeConnections.size).toBe(0)
   })
 
   it('removes connections when closed and supports closeAllConnections', async () => {
     const wsClient1 = createFakeWebSocketClient()
     const wsClient2 = createFakeWebSocketClient()
 
-    mockCreate
-      .mockResolvedValueOnce(wsClient1 as unknown as BaseWebSocketClient)
-      .mockResolvedValueOnce(wsClient2 as unknown as BaseWebSocketClient)
+    mockResolve
+      .mockReturnValueOnce(wsClient1 as unknown as BaseWebSocketClient)
+      .mockReturnValueOnce(wsClient2 as unknown as BaseWebSocketClient)
 
     const stream = new LogsStream({ basePath, authService, logger })
 
@@ -317,13 +328,13 @@ describe('LogsStream', () => {
 
     it('forwards httpsAgent to WebSocketClient.create for each connection', async () => {
       const wsClient = createFakeWebSocketClient()
-      mockCreate.mockResolvedValueOnce(wsClient as unknown as BaseWebSocketClient)
+      mockResolve.mockReturnValueOnce(wsClient as unknown as BaseWebSocketClient)
       const httpsAgent = { destroy: vi.fn() }
 
       const stream = new LogsStream({ basePath, authService, logger, httpsAgent })
       await stream.connectByCore({ onMessage: vi.fn() })
 
-      expect(mockCreate).toHaveBeenCalledWith(expect.any(String), undefined, { agent: httpsAgent })
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), undefined, { agent: httpsAgent })
     })
 
     it('does not warn when no httpsAgent is configured', () => {

--- a/packages/sdk/src/core/ws/logs-stream.ts
+++ b/packages/sdk/src/core/ws/logs-stream.ts
@@ -87,6 +87,34 @@ export class LogsStream {
     }
   }
 
+  private buildWsUrl(endpoint: string, options: LogOptions): string {
+    const wsUrl = configurationUrlWs({
+      basePath: this.basePath,
+      endpoint,
+      token: this.authService.accessToken,
+      interval: options?.interval ?? DEFAULT_WS_INTERVAL,
+    })
+
+    // Redact the token query param so JWTs never leak into logs.
+    const redactedUrl = wsUrl.replace(/(token=)[^&]+/i, '$1***')
+    this.logger.debug(`WebSocket URL generated: ${redactedUrl}`, 'LogsStream')
+
+    return wsUrl
+  }
+
+  /**
+   * Connects `wsClient`'s socket, undoing the `activeConnections` tracking on
+   * failure — a connect that never opens must not leave a dead entry behind.
+   */
+  private async openConnection(wsClient: BaseWebSocketClient): Promise<void> {
+    try {
+      await wsClient.init()
+    } catch (error) {
+      this.activeConnections.delete(wsClient)
+      throw error
+    }
+  }
+
   /**
    * Establishes a WebSocket connection to a specified endpoint.
    * @private
@@ -99,17 +127,12 @@ export class LogsStream {
     this.logger.debug(`Establishing WebSocket connection to: ${endpoint}`, 'LogsStream')
     await this.ensureAuthenticated()
 
-    const wsUrl = configurationUrlWs({
-      basePath: this.basePath,
-      endpoint,
-      token: this.authService.accessToken,
-      interval: options?.interval ?? DEFAULT_WS_INTERVAL,
-    })
+    const wsUrl = this.buildWsUrl(endpoint, options)
 
-    // Redact the token query param so JWTs never leak into logs.
-    const redactedUrl = wsUrl.replace(/(token=)[^&]+/i, '$1***')
-    this.logger.debug(`WebSocket URL generated: ${redactedUrl}`, 'LogsStream')
-    const wsClient: BaseWebSocketClient = await WebSocketClient.create(wsUrl, undefined, { agent: this.httpsAgent })
+    // Resolved (not yet connected) so every listener below is attached before
+    // `init()` constructs the socket — a connect that fails before the first
+    // microtask still reaches `on('error')`/`on('close')` instead of nobody.
+    const wsClient: BaseWebSocketClient = WebSocketClient.resolve(wsUrl, undefined, { agent: this.httpsAgent })
     this.activeConnections.add(wsClient)
 
     // Mutable ref so the close handle returned to the caller always points to
@@ -162,6 +185,8 @@ export class LogsStream {
       this.activeConnections.delete(wsClient)
       this.logger.info(`WebSocket connection closed: ${endpoint}`, 'LogsStream')
     })
+
+    await this.openConnection(wsClient)
 
     return () => closeActive()
   }


### PR DESCRIPTION
## Summary

- `BaseWebSocketClient.init()` constructed the socket inside an `async createWebSocket()`, and `LogsStream` only attached `on()` handlers after `WebSocketClient.create()` resolved — several microtask hops after the socket already existed. A connection that failed inside that window (connection refused, DNS failure, instant handshake rejection) dispatched `error`/`close` to nobody: `onError` never fired, and the dead socket stayed in `activeConnections` forever.
- `createWebSocket()` is now synchronous by contract; `on()`/`close()` calls made before `init()` buffer and flush in the same tick the socket is constructed, so nothing dispatched immediately is missed. `WebSocketClient.resolve()` (sync) is split out from `create()` so `LogsStream` can register listeners before the socket connects.
- `LogsStream.connect()` now resolves the client, registers all listeners, and only then awaits `init()` — a failed connect deletes itself from `activeConnections` instead of leaking.
- Non-breaking; builds on the `ws.Server` test harness from #85.

Closes #86.

## Test plan

- [x] `pnpm --filter marzban-sdk test:coverage` — 685 tests, 100% statements/branches/functions/lines
- [x] `pnpm lint` / `tsc --noEmit` — clean
- [x] `pnpm --filter marzban-sdk test:integration` against a live local panel — 80/80 passing
- [x] Manual repro against the live panel: authorize, stop the panel, `connectByCore()` → `onError` fires with the real `ECONNREFUSED`, `activeConnections.size === 0` (previously: `onError` never called, dead socket left tracked forever)
- [x] `docs/testing.md` updated (WS module section)