### PR TITLE
dev: confirm=auto per-call trust fix, marzban-mcp 0.2.1

### DIFF
--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -86,8 +86,9 @@ the core config. It's a separate, published package (`marzban-mcp`), not a mode 
 - **21 tools, 3 prompts** — the full user lifecycle plus config, hosts, nodes, system stats, and subscriptions,
   and ready-made prompts that chain several tools into one investigation.
 - **Profile-gated access** — a tool outside the active profile never appears in `tools/list` at all.
-- **Confirmation on every destructive action** — a first call only describes the consequences and returns a
-  one-time token; nothing runs until a second, explicitly confirmed call repeats it.
+- **Confirmation on every destructive call** — a first call only describes the consequences and returns a
+  one-time token; nothing runs until a second, explicitly confirmed call repeats it. Confirming one call
+  never authorizes a different target or a wider version of the same call.
 - **Credentials only from environment variables**, masked by default in tool output.
 
 ```json title="claude_desktop_config.json / .mcp.json"

--- a/apps/docs/content/docs/mcp-server/overview.mdx
+++ b/apps/docs/content/docs/mcp-server/overview.mdx
@@ -16,7 +16,7 @@ It's a separate package from the SDK itself. If you're building your own integra
 - **21 tools**, namespaced `marzban_<area>_<action>`, covering the full user lifecycle plus config, hosts, nodes, system stats, and subscriptions.
 - **3 prompts** that chain those tools into ready-made investigations (expiring subscriptions, node health, traffic reports).
 - **Profile-gated access** — a tool outside the active profile never appears in `tools/list` at all, not just hidden behind a hint.
-- **Every destructive action needs confirmation** — a first call only describes the consequences and returns a one-time token; nothing runs until a second, explicitly confirmed call repeats it.
+- **Every destructive call needs confirmation** — a first call only describes the consequences and returns a one-time token; nothing runs until a second, explicitly confirmed call repeats it. Confirming one call never authorizes a different target or a wider version of the same call.
 - **Credentials only from environment variables** — never accepted as a tool argument, so a model can't redirect the server or leak them through a call.
 - **Credential-bearing fields masked by default** — `proxies`, `subscription_url`, and `links` stay hidden unless you opt in.
 

--- a/apps/docs/content/docs/mcp-server/security.mdx
+++ b/apps/docs/content/docs/mcp-server/security.mdx
@@ -66,11 +66,11 @@ The signing key lives only in the server process's memory — a restart invalida
 
 | Mode | Behavior | Best for |
 |---|---|---|
-| `auto` (default) | Confirm once per tool name per connection; after that, calls to the *same tool* proceed without re-asking | Interactive use — balances safety with not re-confirming "delete user" fifty times in a cleanup loop |
+| `auto` (default) | Confirm once per tool name *and* exact arguments; a repeat of that same call proceeds without re-asking, but only within a 5-minute window | Interactive use — a genuine retry (a timeout, a reconnect) doesn't need re-confirming, but nothing broader is ever inferred from it |
 | `always` | Confirm every single call, with no memory of what was already confirmed | Shared or interactive environments where even one accumulated trust is undesirable |
 | `off` | Skip confirmation entirely, from the very first call | Fully automated, unattended environments only — there is no safety net once this is set |
 
-Trust in `auto` mode is granted per tool *name*, not per call's arguments — confirming a delete for `alice` also trusts future deletes for `bob` without re-asking, for the rest of that connection. This is a deliberate, logged trade-off, not an oversight: it's no looser than what a host's own "always allow this tool" consent dialog already permits, just made explicit and auditable on this side. Every action taken under accumulated trust is still written to the audit log described below.
+Trust in `auto` mode is granted per tool *and* per exact call arguments, not per tool name alone — confirming a delete for `alice` does **not** trust a delete for `bob`, and confirming `marzban_users_reset_traffic { username: "alice" }` does not trust the same tool called with `{ all: true }`. Each grant also expires after the same 5-minute window a confirm token uses, so a tool whose arguments never vary (`marzban_core_restart` always takes `{}`) can't turn one confirmation into unlimited free re-runs for the rest of the connection. Every call that proceeds on accumulated trust — rather than a freshly verified token — is logged to stderr.
 
 ## Credential masking
 

--- a/apps/docs/content/docs/modules/users.mdx
+++ b/apps/docs/content/docs/modules/users.mdx
@@ -201,6 +201,13 @@ Permanently delete a user.
 await sdk.user.removeUser('alice')
 ```
 
+<Callout type="info">
+  Some Marzban panels 500 on this endpoint even though the delete succeeded (a
+  panel-side bug building its response). `removeUser` detects exactly that
+  case — confirming via a follow-up lookup — and resolves normally instead of
+  throwing. A genuine failure still throws.
+</Callout>
+
 ---
 
 ### `resetUserDataUsage(username)`

--- a/docs/adr/0013-confirm-auto-trusts-a-call-not-a-tool.md
+++ b/docs/adr/0013-confirm-auto-trusts-a-call-not-a-tool.md
@@ -1,0 +1,93 @@
+# ADR-0013: `confirm: 'auto'` trusts a call, not a tool
+
+Status: Accepted
+Date: 2026-08-31
+
+## Context
+
+ADR-0010 established the profile + confirm security model for
+`packages/mcp`: destructive tools require a short-lived confirmation token
+bound to the exact tool and arguments, unless `MARZBAN_MCP_CONFIRM=off`. What
+that ADR did not specify is what `auto` — the default — should trust once a
+confirmation succeeds.
+
+The implementation trusted the **tool by name**: `core/confirm/confirm.ts`
+kept a `trustedTools: Set<string>` and, once any call to a given tool was
+confirmed, every later call to that same tool proceeded with no further
+prompt, regardless of its arguments (github.com/Ilmar7786/marzban-sdk#74).
+Concretely, in one session:
+
+- Confirming `marzban_users_delete { username: "alice" }` silently
+  authorised deleting `bob`, `carol`, anyone — the argument binding the token
+  itself enforces (`core/confirm/canonical.ts`) was discarded the moment
+  `auto` cached trust by name.
+- Confirming `marzban_users_reset_traffic { username: "alice" }` authorised
+  the same tool called with `{ all: true }` — resetting traffic for every
+  user on the panel. This is exactly the `all: false` → `all: true`
+  substitution the confirm-token mechanics are documented to catch; `auto`
+  threw that guarantee away after the first confirmed call.
+- Confirming one `marzban_config_update` payload authorised any other
+  payload, restarting the core with unreviewed config.
+
+This is a real gap, but a bounded one: destructive tools are not registered
+at all under the default `MARZBAN_MCP_PROFILE=standard` — reaching this
+required an operator to have already opted into `full` — and most MCP hosts
+prompt per `tools/call` on their own side unless a human clicked "always
+allow." What made it worth fixing immediately rather than filing for later
+is that the server's own documentation (`packages/mcp/README.md`,
+`docs/mcp-server/security.mdx`, the docs-site landing page) advertised
+"confirmation on every destructive action" without that caveat — the gap
+between the claim and `auto`'s actual behavior needed to close regardless of
+how a given client's own layers happened to mitigate it.
+
+## Decision
+
+`auto`'s trust is keyed by **tool name and the exact call arguments**
+(`hashCallArgs` — the same canonicalized-argument hash the confirm token
+itself signs, shared between `core/confirm/token.ts` and
+`core/confirm/confirm.ts` so both use one definition of "same call"), and
+each grant **expires after `CONFIRM_TOKEN_TTL_SECONDS`** (5 minutes, the
+same window a confirm token uses).
+
+This was issue #74's "option A" (key by `tool.name + argsHash`) plus a TTL
+that the issue's original proposal didn't include. Keying by exact arguments
+alone is not sufficient on its own: `marzban_core_restart` takes no
+meaningful arguments (`args` is always `{}`), so under plain A, one confirmed
+restart would grant unlimited further restarts for the rest of the
+connection — the same shape of bug this ADR fixes, just triggered by a
+tool whose arguments never vary instead of ones that do. The TTL closes that
+case without reopening the "re-confirm every call" cost A was meant to avoid.
+
+Option B from the issue — ignore `auto` for `destructive` tools entirely,
+requiring a fresh token on every call — was considered and rejected as the
+default behavior: it collapses into `always`, discarding `auto`'s only
+purpose (not re-asking for an honest retry of the exact same operation,
+e.g. after a client timeout or reconnect). `always` already exists as an
+explicit choice for operators who want that stricter posture.
+
+Every call that proceeds on accumulated trust (rather than a freshly
+verified token) is logged via the server's stderr logger. The confirmation
+flow's own documentation (`security.mdx`) previously claimed this was
+"written to the audit log described below" — no such audit log exists
+anywhere in the repository. That claim is corrected to describe the actual
+stderr logging rather than a mechanism that was never built.
+
+## Consequences
+
+- `auto`'s remaining difference from `always` narrows to exactly one thing:
+  a genuine retry of the identical call, within 5 minutes, doesn't re-prompt.
+  Everything else — a different target, a wider version of the same call, or
+  the same call after the window closes — now behaves like `always`.
+- The convenience `auto` previously offered — confirm once, then delete
+  fifty users in a cleanup loop without fifty prompts — is gone by design.
+  That behavior is what made the bug possible; there is no way to keep it
+  without re-introducing trust that outlives the specific operation it was
+  granted for.
+- `hashCallArgs` (in `core/confirm/canonical.ts`) is now a small shared
+  primitive, not private to the token codec. #76 (idempotency keys for
+  destructive tools) proposes the identical `tool.name + canonicalize(args)`
+  key for its own dedup store and can reuse this helper directly instead of
+  redefining it.
+- #78 (migrating confirmation to MRTR elicitation) inherits this semantics
+  unchanged — what changes there is the transport of the confirmation
+  round-trip, not what a successful confirmation is scoped to.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,3 +53,4 @@ What this enables, what it costs.
 | [0010](./0010-mcp-stdio-env-config-security-model.md)                | MCP: stdio only, env-only config, profile + confirm security model  |
 | [0011](./0011-per-package-release-workflows-and-mcp-docker-build.md) | Per-package release workflows; mcp's Docker image built from source |
 | [0012](./0012-gate-dev-with-ci.md)                                   | Gate `dev`, not just `main`, with CI and branch protection          |
+| [0013](./0013-confirm-auto-trusts-a-call-not-a-tool.md)              | `confirm: 'auto'` trusts a call, not a tool                         |

--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -44,32 +44,49 @@ the deferred background task. The delete is not lost; only the HTTP response
 is. Confirm the outcome with a follow-up `GET` (404), not by the delete call
 resolving.
 
-**Concrete repro:** `dbuser.admin` is `None` whenever the user's `admin_id`
-no longer resolves to a live `Admin` row. Reproduced end-to-end: a non-sudo
-admin (`owner1`) creates a user → the user's `admin_id` points at `owner1`;
-a sudo admin then deletes `owner1` (`DELETE /api/admin/owner1`) — there's no
-`ON DELETE SET NULL`/cascade, so `dbuser.admin` simply stops resolving on
-the next read (confirmed via `GET /api/user/{username}` showing `"admin":
-null` right after the admin delete); any subsequent `DELETE
-/api/user/{username}` for that user then 500s as above. Marzban supports
-multiple admins and multiple users per panel — this isn't an edge case
-limited to a single-admin setup, just one that needs a second admin in the
-picture to trigger.
+**Concrete repro (primary path — no second admin needed):** `dbuser.admin`
+is `None` whenever the user's `admin_id` doesn't resolve to a live `Admin`
+row. The most common way to land there: the env-configured sudo admin
+(`SUDO_USERNAME`/`SUDO_PASSWORD`) has **no row in the `admins` table at
+all** — `Admin.get_admin()` (`app/models/admin.py`) short-circuits and
+builds a Pydantic `Admin` straight from the JWT payload when the token's
+username is in `SUDOERS`, never touching the DB. `add_user`
+(`app/routers/user.py`) then does `admin=crud.get_admin(db,
+admin.username)` — a plain DB lookup by username — which returns `None` for
+that admin. So **any user created by the default env sudo login already has
+`admin_id: null` from the moment it's created** (confirmed via `GET
+/api/user/{username}` showing `"admin": null` right after creation, no
+extra step). `DELETE`ing it then 500s as above. This is why the bug is
+"reliable" in the integration suite: it authenticates as exactly that env
+sudo admin.
 
-**Workaround:** `removeUserTolerantly()` in
+**Secondary path (also verified, needs two admins):** a non-sudo admin
+(created through the API, so it _does_ have an `admins` row) creates a
+user → the user's `admin_id` points at that admin; a sudo admin later
+deletes it (`DELETE /api/admin/{username}`) — there's no `ON DELETE SET
+NULL`/cascade, so `dbuser.admin` stops resolving on the next read. Same
+symptom, different route to it. Either way, this isn't an edge case scoped
+to unusual setups — it's the default outcome of the single most common
+setup (one env-configured sudo admin managing its own users directly).
+
+**Workaround:** `sdk.user.removeUser()` in `packages/sdk` catches exactly a
+500 from this endpoint and confirms the delete via a follow-up `getUser`
+(expecting 404) before treating it as success — see
+[`TolerantUserApi`](../packages/sdk/src/core/quirks/tolerant-user-api.ts). A
+genuine failure (the follow-up `getUser` shows the user still exists, or
+the confirmation itself can't be made) still throws. The integration
+suite's own `removeUserTolerantly()` in
 [`packages/sdk/test/integration/helpers/quirks.ts`](../packages/sdk/test/integration/helpers/quirks.ts)
 and the mirrored helper in
 [`packages/mcp/test/integration/helpers/quirks.ts`](../packages/mcp/test/integration/helpers/quirks.ts)
-— catches exactly a 500 from `removeUser` and treats it as success.
+now just call `sdk.user.removeUser()` directly — the tolerance itself moved
+into the SDK, and the wrapper only remains to add
+[`freshConnectionConfig()`](../packages/sdk/test/integration/helpers/quirks.ts)
+(a one-off connection), so that the SDK's own internal confirmation call
+doesn't draw the poisoned socket left behind by the crash.
 
-**Open:** the SDK itself does not currently special-case this — a real
-caller of `sdk.user.removeUser()` against an affected Marzban version still
-sees an `HttpError` on a successful delete, and hitting it only requires a
-panel with more than one admin. Tracked in
-[issue #103](https://github.com/Ilmar7786/marzban-sdk/issues/103): whether
-that tolerance belongs in the SDK proper (and, if so, how narrowly to scope
-it so a _genuine_ 500 elsewhere isn't silently swallowed) or stays
-test-only.
+Resolved in [issue #103](https://github.com/Ilmar7786/marzban-sdk/issues/103),
+shipping in `sdk-v3.3.0`.
 
 ## The 500 above can poison the next request on the same connection
 

--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -17,13 +17,44 @@ are Marzban's behavior; we document and work around them defensively.
 
 ## `DELETE /api/user/{username}` 500s despite deleting the user
 
-**Verified against:** `gozargah/marzban:latest`, `local/marzban/`.
+**Verified against:** `gozargah/marzban:v0.8.4` (both the pinned tag and
+current `master` on GitHub have byte-identical code — this is not fixed
+upstream), `local/marzban/` (reproduced from a freshly recreated container,
+empty DB).
 
 The server removes the user row, then crashes building the deletion report —
-`Admin.model_validate(dbuser.admin)` on `None` (the user has no owning
-admin), in Marzban's `app/routers/user.py` `remove_user` — before it can
-send a response. The delete is not lost; only the HTTP response is. Confirm
-the outcome with a follow-up `GET` (404), not by the delete call resolving.
+`Admin.model_validate(dbuser.admin)` on `None` — in Marzban's
+`app/routers/user.py` `remove_user`, before it can send a response:
+
+```python
+def remove_user(...):
+    crud.remove_user(db, dbuser)                       # delete already committed
+    bg.add_task(xray.operations.remove_user, dbuser=dbuser)
+    bg.add_task(
+        report.user_deleted, username=dbuser.username,
+        user_admin=Admin.model_validate(dbuser.admin),  # raises here, synchronously
+        by=admin
+    )
+    return {"detail": "User successfully deleted"}      # never reached
+```
+
+`bg.add_task(fn, *args)`'s arguments are evaluated immediately (it's a plain
+function call) — the crash happens inside the endpoint body itself, not in
+the deferred background task. The delete is not lost; only the HTTP response
+is. Confirm the outcome with a follow-up `GET` (404), not by the delete call
+resolving.
+
+**Concrete repro:** `dbuser.admin` is `None` whenever the user's `admin_id`
+no longer resolves to a live `Admin` row. Reproduced end-to-end: a non-sudo
+admin (`owner1`) creates a user → the user's `admin_id` points at `owner1`;
+a sudo admin then deletes `owner1` (`DELETE /api/admin/owner1`) — there's no
+`ON DELETE SET NULL`/cascade, so `dbuser.admin` simply stops resolving on
+the next read (confirmed via `GET /api/user/{username}` showing `"admin":
+null` right after the admin delete); any subsequent `DELETE
+/api/user/{username}` for that user then 500s as above. Marzban supports
+multiple admins and multiple users per panel — this isn't an edge case
+limited to a single-admin setup, just one that needs a second admin in the
+picture to trigger.
 
 **Workaround:** `removeUserTolerantly()` in
 [`packages/sdk/test/integration/helpers/quirks.ts`](../packages/sdk/test/integration/helpers/quirks.ts)
@@ -33,9 +64,12 @@ and the mirrored helper in
 
 **Open:** the SDK itself does not currently special-case this — a real
 caller of `sdk.user.removeUser()` against an affected Marzban version still
-sees an `HttpError` on a successful delete. Worth deciding whether that
-tolerance belongs in the SDK proper (and, if so, how narrowly to scope it so
-a _genuine_ 500 elsewhere isn't silently swallowed) or stays test-only.
+sees an `HttpError` on a successful delete, and hitting it only requires a
+panel with more than one admin. Tracked in
+[issue #103](https://github.com/Ilmar7786/marzban-sdk/issues/103): whether
+that tolerance belongs in the SDK proper (and, if so, how narrowly to scope
+it so a _genuine_ 500 elsewhere isn't silently swallowed) or stays
+test-only.
 
 ## The 500 above can poison the next request on the same connection
 

--- a/packages/mcp/ARCHITECTURE.md
+++ b/packages/mcp/ARCHITECTURE.md
@@ -64,7 +64,8 @@ flowchart LR
   carries a TTL, a hash of the canonicalized arguments, and a per-process
   signing key; it's rejected on tool mismatch, argument mismatch, or reuse.
   `MARZBAN_MCP_CONFIRM` controls the mode: `off`, `auto` (confirm once per
-  tool per session), `always`.
+  tool _and_ exact arguments, trusted for the same TTL as the token —
+  `core/confirm/confirm.ts`'s `trustedCalls`), `always`.
 - **Handlers return plain data**, never a `CallToolResult` — rendering and
   error mapping are the pipeline's job, not the tool's.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -62,7 +62,7 @@ and the tools below become available.
 
 - 🔒 **Env-only credentials** — the panel URL, username and password are never accepted as a tool argument, so a compromised or confused model can't redirect the server elsewhere.
 - 🎯 **Profile-gated tools** — a tool outside the active profile never appears in `tools/list` at all, not just hidden behind a hint.
-- ✅ **Confirmation on every destructive action** — the first call only describes the consequences and returns a one-time token; nothing runs until a human-approved second call repeats it.
+- ✅ **Confirmation on every destructive call** — the first call only describes the consequences and returns a one-time token; nothing runs until a human-approved second call repeats it, and confirming one call never authorizes a different target or a wider version of the same call.
 - 🙈 **Credentials masked by default** — `proxies`, `subscription_url` and `links` stay hidden unless you explicitly opt in.
 - 🧭 **21 tools, 3 prompts** — full user lifecycle, config, hosts, nodes, system stats and subscriptions, plus ready-made investigations that chain several tools together.
 - 🛠️ **Built on `marzban-sdk`** — the same typed client, auth and retry behavior as the SDK, just exposed as MCP tools.
@@ -99,9 +99,10 @@ config, restart the core.
 Destructive tools also gate on confirmation: the first call never runs
 anything — it describes exactly what would happen and returns a one-time
 token. Only a second call, with that token attached, executes. `MARZBAN_MCP_CONFIRM`
-controls how often this is required: `auto` (default, once per tool per
-session), `always` (every call), or `off` (unattended environments only —
-no safety net once set).
+controls how often this is required: `auto` (default, once per tool _and_
+exact arguments, for 5 minutes — a different target or a wider call always
+needs its own confirmation), `always` (every call), or `off` (unattended
+environments only — no safety net once set).
 
 ## Documentation
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marzban-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "mcpName": "io.github.ilmar7786/marzban-mcp",
   "description": "MCP server for the Marzban API, built on marzban-sdk.",
   "keywords": [

--- a/packages/mcp/src/core/confirm/canonical.test.ts
+++ b/packages/mcp/src/core/confirm/canonical.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { canonicalize } from './canonical'
+import { canonicalize, hashCallArgs } from './canonical'
 
 describe('canonicalize', () => {
   it('produces the same string regardless of key order', () => {
@@ -23,5 +23,27 @@ describe('canonicalize', () => {
 
   it('produces different strings for different values', () => {
     expect(canonicalize({ a: 1 })).not.toBe(canonicalize({ a: 2 }))
+  })
+})
+
+describe('hashCallArgs', () => {
+  it('ignores confirmToken', () => {
+    expect(hashCallArgs({ username: 'alice', confirmToken: 'abc' })).toBe(hashCallArgs({ username: 'alice' }))
+  })
+
+  it('is unaffected by key order', () => {
+    expect(hashCallArgs({ b: 1, a: 2 })).toBe(hashCallArgs({ a: 2, b: 1 }))
+  })
+
+  it('differs for different arguments', () => {
+    expect(hashCallArgs({ username: 'alice' })).not.toBe(hashCallArgs({ username: 'bob' }))
+  })
+
+  it('differs when a boolean flag flips', () => {
+    expect(hashCallArgs({ all: false })).not.toBe(hashCallArgs({ all: true }))
+  })
+
+  it('handles undefined args', () => {
+    expect(hashCallArgs(undefined)).toBe(hashCallArgs({}))
   })
 })

--- a/packages/mcp/src/core/confirm/canonical.ts
+++ b/packages/mcp/src/core/confirm/canonical.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 /**
  * Deterministic JSON serialization — object keys sorted recursively, so the
  * same logical arguments always hash to the same string regardless of the
@@ -5,6 +7,19 @@
  */
 export function canonicalize(value: unknown): string {
   return JSON.stringify(sortKeysDeep(value))
+}
+
+/**
+ * SHA-256 of the canonicalized call arguments, minus `confirmToken` — the
+ * one field that must never affect the hash, since it carries a fresh `jti`
+ * per mint and would otherwise turn every retry into a different key.
+ * Shared by the confirm-token binding (`token.ts`) and the `auto` trust
+ * cache (`confirm.ts`) so both use exactly the same notion of "same call".
+ */
+export function hashCallArgs(args: unknown): string {
+  const rest: Record<string, unknown> = { ...(args as Record<string, unknown> | undefined) }
+  delete rest.confirmToken
+  return createHash('sha256').update(canonicalize(rest)).digest('hex')
 }
 
 function sortKeysDeep(value: unknown): unknown {

--- a/packages/mcp/src/core/confirm/confirm.test.ts
+++ b/packages/mcp/src/core/confirm/confirm.test.ts
@@ -106,7 +106,7 @@ describe('createConfirmFn', () => {
     expect(ctx.logger.warn).toHaveBeenCalledWith(expect.stringContaining('Rejected confirmToken'))
   })
 
-  it('auto: trusts the tool after one confirmed call, so a later call with no token proceeds', async () => {
+  it('auto: a confirmed call does not authorize the same tool with different arguments', async () => {
     const confirm = createConfirmFn()
     const tool = makeTool()
     const ctx = makeContext('auto')
@@ -117,7 +117,59 @@ describe('createConfirmFn', () => {
     await confirm({ tool, args: { ...args, confirmToken: token }, ctx, serverCtx: fakeServerCtx })
 
     const third = await confirm({ tool, args: { username: 'bob' }, ctx, serverCtx: fakeServerCtx })
-    expect(third).toEqual({ proceed: true })
+    expect(third.proceed).toBe(false)
+  })
+
+  it('auto: a confirmed call does not authorize a wider version of the same call', async () => {
+    const confirm = createConfirmFn()
+    const tool = makeTool({
+      inputSchema: z.object({ all: z.boolean().optional(), confirmToken: z.string().optional() }),
+    })
+    const ctx = makeContext('auto')
+    const args = { all: false }
+
+    const first = await confirm({ tool, args, ctx, serverCtx: fakeServerCtx })
+    const token = first.message!.match(/confirmToken: "([^"]+)"/)![1]
+    await confirm({ tool, args: { ...args, confirmToken: token }, ctx, serverCtx: fakeServerCtx })
+
+    const wider = await confirm({ tool, args: { all: true }, ctx, serverCtx: fakeServerCtx })
+    expect(wider.proceed).toBe(false)
+  })
+
+  it('auto: a confirmed call proceeds again with the same arguments, within the TTL', async () => {
+    const confirm = createConfirmFn()
+    const tool = makeTool()
+    const ctx = makeContext('auto')
+    const args = { username: 'alice' }
+
+    const first = await confirm({ tool, args, ctx, serverCtx: fakeServerCtx })
+    const token = first.message!.match(/confirmToken: "([^"]+)"/)![1]
+    await confirm({ tool, args: { ...args, confirmToken: token }, ctx, serverCtx: fakeServerCtx })
+
+    const again = await confirm({ tool, args, ctx, serverCtx: fakeServerCtx })
+    expect(again).toEqual({ proceed: true })
+    expect(ctx.logger.info).toHaveBeenCalledWith(expect.stringContaining('accumulated confirm trust'))
+  })
+
+  it('auto: trust for the same arguments expires after the confirm-token TTL', async () => {
+    vi.useFakeTimers()
+    try {
+      const confirm = createConfirmFn()
+      const tool = makeTool()
+      const ctx = makeContext('auto')
+      const args = { username: 'alice' }
+
+      const first = await confirm({ tool, args, ctx, serverCtx: fakeServerCtx })
+      const token = first.message!.match(/confirmToken: "([^"]+)"/)![1]
+      await confirm({ tool, args: { ...args, confirmToken: token }, ctx, serverCtx: fakeServerCtx })
+
+      vi.advanceTimersByTime(301_000)
+
+      const again = await confirm({ tool, args, ctx, serverCtx: fakeServerCtx })
+      expect(again.proceed).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('always: never trusts the tool, so every call needs its own confirmation', async () => {

--- a/packages/mcp/src/core/confirm/confirm.ts
+++ b/packages/mcp/src/core/confirm/confirm.ts
@@ -1,4 +1,5 @@
 import type { ConfirmDecision, ConfirmFn } from '../tool'
+import { hashCallArgs } from './canonical'
 import { CONFIRM_TOKEN_TTL_SECONDS, createConfirmTokenCodec } from './token'
 
 function extractConfirmToken(args: unknown): string | undefined {
@@ -27,30 +28,57 @@ function buildConfirmationMessage(consequences: string, token: string): string {
   ].join(' ')
 }
 
+function callKey(toolName: string, args: unknown): string {
+  return `${toolName}:${hashCallArgs(args)}`
+}
+
 /**
  * Builds the real confirm strategy (plan §6.1–§6.2, confirm_token branch
  * only — native MRTR elicitation is left for a later iteration, see the
  * step-5 commit message for why). One instance owns one signing key and one
- * `trustedTools` set, both scoped to the server instance's lifetime — a
+ * `trustedCalls` map, both scoped to the server instance's lifetime — a
  * fresh `createMarzbanMcpServer()` call (i.e. a restart) starts over, which
  * is the intended behavior (plan §6.1/§6.6).
+ *
+ * `trustedCalls` keys trust by tool name *and* the exact call arguments
+ * (see issue #74) — confirming `marzban_users_delete` for "alice" must not
+ * silently authorise deleting "bob", or resetting *every* user's traffic
+ * once `{ username }` was confirmed. Each entry also carries the same TTL as
+ * a confirm token (`CONFIRM_TOKEN_TTL_SECONDS`): without an expiry, a tool
+ * whose arguments never vary (`marzban_core_restart` always takes `{}`)
+ * would get an unlimited number of free re-runs from a single confirmation.
  */
 export function createConfirmFn(): ConfirmFn {
   const codec = createConfirmTokenCodec(crypto.getRandomValues(new Uint8Array(32)))
-  const trustedTools = new Set<string>()
+  const trustedCalls = new Map<string, number>()
+
+  function pruneExpired(now: number): void {
+    for (const [key, expiresAt] of trustedCalls) {
+      if (expiresAt <= now) trustedCalls.delete(key)
+    }
+  }
 
   return async function confirm({ tool, args, ctx, serverCtx }): Promise<ConfirmDecision> {
     if (ctx.config.confirm === 'off') return { proceed: true }
 
-    if (ctx.config.confirm === 'auto' && trustedTools.has(tool.name)) {
-      return { proceed: true }
+    const key = callKey(tool.name, args)
+
+    if (ctx.config.confirm === 'auto') {
+      const now = Date.now()
+      pruneExpired(now)
+      if (trustedCalls.has(key)) {
+        ctx.logger.info(`Proceeding on accumulated confirm trust for ${tool.name} (same call, still within TTL).`)
+        return { proceed: true }
+      }
     }
 
     const token = extractConfirmToken(args)
     if (token) {
       const result = await codec.verify(token, tool.name, args, serverCtx)
       if (result.ok) {
-        if (ctx.config.confirm === 'auto') trustedTools.add(tool.name)
+        if (ctx.config.confirm === 'auto') {
+          trustedCalls.set(key, Date.now() + CONFIRM_TOKEN_TTL_SECONDS * 1000)
+        }
         return { proceed: true }
       }
       ctx.logger.warn(`Rejected confirmToken for ${tool.name}: ${result.reason}`)

--- a/packages/mcp/src/core/confirm/token.ts
+++ b/packages/mcp/src/core/confirm/token.ts
@@ -1,8 +1,8 @@
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 
 import { createRequestStateCodec, type ServerContext } from '@modelcontextprotocol/server'
 
-import { canonicalize } from './canonical'
+import { hashCallArgs } from './canonical'
 
 /** How long a minted confirm_token stays valid (plan §6.1). */
 export const CONFIRM_TOKEN_TTL_SECONDS = 300
@@ -22,12 +22,6 @@ export type ConfirmVerifyResult =
 export interface ConfirmTokenCodec {
   mint(tool: string, args: unknown, ctx: ServerContext): Promise<string>
   verify(token: string, tool: string, args: unknown, ctx: ServerContext): Promise<ConfirmVerifyResult>
-}
-
-function hashArgs(args: unknown): string {
-  const rest: Record<string, unknown> = { ...(args as Record<string, unknown> | undefined) }
-  delete rest.confirmToken
-  return createHash('sha256').update(canonicalize(rest)).digest('hex')
 }
 
 /**
@@ -52,7 +46,7 @@ export function createConfirmTokenCodec(key: Uint8Array): ConfirmTokenCodec {
 
   return {
     async mint(tool, args, ctx) {
-      return codec.mint({ jti: randomUUID(), tool, argsHash: hashArgs(args) }, ctx)
+      return codec.mint({ jti: randomUUID(), tool, argsHash: hashCallArgs(args) }, ctx)
     },
 
     async verify(token, tool, args, ctx) {
@@ -64,7 +58,7 @@ export function createConfirmTokenCodec(key: Uint8Array): ConfirmTokenCodec {
       }
 
       if (payload.tool !== tool) return { ok: false, reason: 'tool-mismatch' }
-      if (payload.argsHash !== hashArgs(args)) return { ok: false, reason: 'args-mismatch' }
+      if (payload.argsHash !== hashCallArgs(args)) return { ok: false, reason: 'args-mismatch' }
 
       const now = Date.now()
       pruneExpired(now)

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -20,6 +20,7 @@ const SERVER_INSTRUCTIONS = `This server manages a Marzban VPN panel. A few rule
 - \`proxies\`, \`subscription_url\`, and \`links\` are access credentials, not display data. Don't paste them into chat unless the user explicitly asks to see them and the server has been configured to reveal them (they're masked by default).
 - Before a real marzban_config_update, call it once with \`dryRun: true\` and show the user the diff. Only send the real write after they've seen it and agreed — it restarts the core and drops every connection.
 - A destructive tool's first response describes what it would do and includes a confirmToken. Only repeat the call with that token after the user has given their own, unprompted "yes" — the token being available is not itself permission.
+- Confirming a destructive call only covers that exact tool and those exact arguments. A different target, or a wider version of the same call (e.g. adding \`all: true\`), needs its own confirmation.
 - For multi-step investigations (expiring subscriptions, node health, bandwidth), check whether a prompt already covers it (expiring_users_audit, node_diagnostics, traffic_report) before improvising a tool sequence by hand.`
 
 // tools/list is fully determined by MARZBAN_MCP_PROFILE/_TOOLS_ALLOW/_TOOLS_DENY,

--- a/packages/mcp/test/integration/helpers/quirks.ts
+++ b/packages/mcp/test/integration/helpers/quirks.ts
@@ -1,19 +1,17 @@
-import { isHttpError, type MarzbanSDK } from 'marzban-sdk'
+import type { MarzbanSDK } from 'marzban-sdk'
 
 import { tlsAgent } from './tls'
 
 // Mirrors packages/sdk/test/integration/helpers/quirks.ts — see
 // docs/marzban-quirks.md for the full writeup of what's worked around here.
+// sdk.user.removeUser() itself absorbs the 500-despite-success quirk now;
+// this wrapper only adds a fresh connection so the internal confirmation
+// doesn't draw the poisoned socket the crash can leave behind.
 
 export function freshConnectionConfig(): Record<string, unknown> {
   return { httpsAgent: tlsAgent() }
 }
 
 export async function removeUserTolerantly(sdk: MarzbanSDK, username: string): Promise<void> {
-  try {
-    await sdk.user.removeUser(username, freshConnectionConfig())
-  } catch (err) {
-    if (isHttpError(err) && err.status === 500) return
-    throw err
-  }
+  await sdk.user.removeUser(username, freshConnectionConfig())
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marzban-sdk",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "description": "The complete TypeScript SDK for the Marzban API — fully typed endpoints, auto token refresh, retries, WebSocket log streaming, webhooks and Zod validation. Isomorphic for Node.js and the browser.",
   "keywords": [
     "marzban-sdk",

--- a/packages/sdk/src/core/MarzbanSDK.ts
+++ b/packages/sdk/src/core/MarzbanSDK.ts
@@ -5,6 +5,7 @@ import { AuthManager } from './auth'
 import { SdkError } from './errors'
 import { configureHttpClient } from './http'
 import { createLogger, Logger } from './logger'
+import { TolerantUserApi } from './quirks/tolerant-user-api'
 import { WebhookManager } from './webhook'
 import { LogsStream } from './ws'
 
@@ -35,6 +36,9 @@ export class MarzbanSDK {
 
   /**
    * User management API endpoints.
+   *
+   * `removeUser` tolerates the Marzban panel-side 500 that follows a
+   * successful delete — see docs/marzban-quirks.md.
    */
   readonly user: userApi
 
@@ -137,7 +141,7 @@ export class MarzbanSDK {
     this.admin = new adminApi({ client: http.client })
     this.core = new coreApi({ client: http.client })
     this.node = new nodeApi({ client: http.client })
-    this.user = new userApi({ client: http.client })
+    this.user = new TolerantUserApi({ client: http.client })
     this.system = new systemApi({ client: http.client })
     this.subscription = new subscriptionApi({ client: http.client })
     this.userTemplate = new userTemplateApi({ client: http.client })

--- a/packages/sdk/src/core/quirks/tolerant-user-api.test.ts
+++ b/packages/sdk/src/core/quirks/tolerant-user-api.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AnyType } from '@/common'
+
+import { HttpError } from '../errors'
+import { TolerantUserApi } from './tolerant-user-api'
+
+// A minimal userResponseSchema-valid payload — only used to make a
+// successful getUser() call resolve without a schema-validation error.
+const EXISTING_USER = {
+  proxies: {},
+  username: 'orphantest',
+  status: 'active',
+  used_traffic: 0,
+  created_at: '2026-01-01T00:00:00',
+}
+
+function httpError(status: number): HttpError {
+  return new HttpError({ response: { status } })
+}
+
+function mockClient(): AnyType {
+  return vi.fn()
+}
+
+describe('TolerantUserApi', () => {
+  it('returns the response as-is when removeUser succeeds directly', async () => {
+    const client = mockClient()
+    client.mockResolvedValueOnce({ data: { detail: 'User successfully deleted' } })
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('someuser')).resolves.toEqual({ detail: 'User successfully deleted' })
+    expect(client).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows a non-500 HttpError without confirming via getUser', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(404))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('someuser')).rejects.toMatchObject({ status: 404 })
+    expect(client).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows a non-HttpError without confirming via getUser', async () => {
+    const networkError = new Error('socket hang up')
+    const client = mockClient()
+    client.mockRejectedValueOnce(networkError)
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('someuser')).rejects.toBe(networkError)
+    expect(client).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a 500 as success once a follow-up getUser confirms 404', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockRejectedValueOnce(httpError(404))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).resolves.toEqual({ detail: 'User successfully deleted' })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original 500 when the follow-up getUser shows the user still exists', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockResolvedValueOnce({ data: EXISTING_USER })
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).rejects.toMatchObject({ status: 500 })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original 500 when the follow-up getUser fails with a non-404 HttpError', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockRejectedValueOnce(httpError(401))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).rejects.toMatchObject({ status: 500 })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original 500 when the follow-up getUser fails with a non-HttpError', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockRejectedValueOnce(new Error('socket hang up'))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).rejects.toMatchObject({ status: 500 })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/sdk/src/core/quirks/tolerant-user-api.ts
+++ b/packages/sdk/src/core/quirks/tolerant-user-api.ts
@@ -1,0 +1,42 @@
+import type { Client, RequestConfig } from '@kubb/plugin-client/clients/axios'
+
+import { userApi } from '@/gen/api'
+import type { RemoveUserPathParams } from '@/gen/models/UserModel/RemoveUser'
+
+import { isHttpError } from '../errors'
+
+/**
+ * `userApi` with the `DELETE /api/user/{username}` 500-despite-success quirk
+ * absorbed — see docs/marzban-quirks.md. Marzban deletes the user, then
+ * crashes building an unrelated deletion report before it can send the
+ * response. A 500 from `removeUser` is only treated as success once a
+ * follow-up `getUser` confirms the user is actually gone (404) — a genuine
+ * failure (user still exists, or the confirmation itself can't be made)
+ * still throws the original error.
+ */
+export class TolerantUserApi extends userApi {
+  async removeUser(
+    username: RemoveUserPathParams['username'],
+    config: Partial<RequestConfig> & { client?: Client } = {}
+  ) {
+    try {
+      return await super.removeUser(username, config)
+    } catch (err) {
+      if (!isHttpError(err) || err.status !== 500) throw err
+      if (await this.stillExists(username, config)) throw err
+      return { detail: 'User successfully deleted' }
+    }
+  }
+
+  private async stillExists(
+    username: RemoveUserPathParams['username'],
+    config: Partial<RequestConfig> & { client?: Client }
+  ): Promise<boolean> {
+    try {
+      await this.getUser(username, config)
+      return true
+    } catch (err) {
+      return !(isHttpError(err) && err.status === 404)
+    }
+  }
+}

--- a/packages/sdk/test/integration/helpers/quirks.ts
+++ b/packages/sdk/test/integration/helpers/quirks.ts
@@ -1,4 +1,4 @@
-import { isHttpError, type MarzbanSDK } from '../../../src/index'
+import type { MarzbanSDK } from '../../../src/index'
 import { tlsAgent } from './tls'
 
 // Real Marzban panel behavior worked around below — see
@@ -19,18 +19,15 @@ export function freshConnectionConfig(): Record<string, unknown> {
 }
 
 /**
- * `removeUser` reliably rejects with a 500 even when the delete succeeded
- * (docs/marzban-quirks.md: "DELETE /api/user/{username} 500s despite
- * deleting the user"). Use this wherever a test needs to actually remove a
- * user (cleanup or the delete test itself); verify the outcome via a
- * follow-up `getUser` 404 (with {@link freshConnectionConfig}), not via
- * this resolving.
+ * `sdk.user.removeUser()` itself now absorbs the panel's 500-despite-success
+ * quirk (docs/marzban-quirks.md: "DELETE /api/user/{username} 500s despite
+ * deleting the user"), confirming via its own follow-up `getUser` before
+ * treating a 500 as success. This wrapper only adds
+ * {@link freshConnectionConfig} — a one-off connection, so that internal
+ * confirmation (and any later call reusing the pool) doesn't draw the
+ * poisoned socket the crash can leave behind. Use this wherever a test needs
+ * to actually remove a user (cleanup or the delete test itself).
  */
 export async function removeUserTolerantly(sdk: MarzbanSDK, username: string): Promise<void> {
-  try {
-    await sdk.user.removeUser(username, freshConnectionConfig())
-  } catch (err) {
-    if (isHttpError(err) && err.status === 500) return
-    throw err
-  }
+  await sdk.user.removeUser(username, freshConnectionConfig())
 }


### PR DESCRIPTION
## Summary

Merges the fix for #74 (`confirm: 'auto'` trusted a destructive tool by name after one confirmed call, instead of by exact call arguments) from `dev` into `main`, plus the accompanying `marzban-mcp` version bump.

- #101 — fix + tests + docs + ADR-0013 (already reviewed/merged into `dev`)
- Version bump: `marzban-mcp` 0.2.0 → 0.2.1

Merging triggers `release-mcp.yml` (npm publish + Docker image push) per the standard release flow.

## Test plan

- [x] `pnpm --filter marzban-mcp test:coverage` — 100% coverage maintained
- [x] `pnpm --filter marzban-mcp types:check`
- [x] `pnpm --filter marzban-mcp lint`
- [ ] CI green on this PR before merge