### PR TITLE
fix(sdk): tolerate the removeUser 500 that follows a successful delete

### DIFF
--- a/apps/docs/content/docs/modules/users.mdx
+++ b/apps/docs/content/docs/modules/users.mdx
@@ -201,6 +201,13 @@ Permanently delete a user.
 await sdk.user.removeUser('alice')
 ```
 
+<Callout type="info">
+  Some Marzban panels 500 on this endpoint even though the delete succeeded (a
+  panel-side bug building its response). `removeUser` detects exactly that
+  case — confirming via a follow-up lookup — and resolves normally instead of
+  throwing. A genuine failure still throws.
+</Callout>
+
 ---
 
 ### `resetUserDataUsage(username)`

--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -44,32 +44,49 @@ the deferred background task. The delete is not lost; only the HTTP response
 is. Confirm the outcome with a follow-up `GET` (404), not by the delete call
 resolving.
 
-**Concrete repro:** `dbuser.admin` is `None` whenever the user's `admin_id`
-no longer resolves to a live `Admin` row. Reproduced end-to-end: a non-sudo
-admin (`owner1`) creates a user → the user's `admin_id` points at `owner1`;
-a sudo admin then deletes `owner1` (`DELETE /api/admin/owner1`) — there's no
-`ON DELETE SET NULL`/cascade, so `dbuser.admin` simply stops resolving on
-the next read (confirmed via `GET /api/user/{username}` showing `"admin":
-null` right after the admin delete); any subsequent `DELETE
-/api/user/{username}` for that user then 500s as above. Marzban supports
-multiple admins and multiple users per panel — this isn't an edge case
-limited to a single-admin setup, just one that needs a second admin in the
-picture to trigger.
+**Concrete repro (primary path — no second admin needed):** `dbuser.admin`
+is `None` whenever the user's `admin_id` doesn't resolve to a live `Admin`
+row. The most common way to land there: the env-configured sudo admin
+(`SUDO_USERNAME`/`SUDO_PASSWORD`) has **no row in the `admins` table at
+all** — `Admin.get_admin()` (`app/models/admin.py`) short-circuits and
+builds a Pydantic `Admin` straight from the JWT payload when the token's
+username is in `SUDOERS`, never touching the DB. `add_user`
+(`app/routers/user.py`) then does `admin=crud.get_admin(db,
+admin.username)` — a plain DB lookup by username — which returns `None` for
+that admin. So **any user created by the default env sudo login already has
+`admin_id: null` from the moment it's created** (confirmed via `GET
+/api/user/{username}` showing `"admin": null` right after creation, no
+extra step). `DELETE`ing it then 500s as above. This is why the bug is
+"reliable" in the integration suite: it authenticates as exactly that env
+sudo admin.
 
-**Workaround:** `removeUserTolerantly()` in
+**Secondary path (also verified, needs two admins):** a non-sudo admin
+(created through the API, so it _does_ have an `admins` row) creates a
+user → the user's `admin_id` points at that admin; a sudo admin later
+deletes it (`DELETE /api/admin/{username}`) — there's no `ON DELETE SET
+NULL`/cascade, so `dbuser.admin` stops resolving on the next read. Same
+symptom, different route to it. Either way, this isn't an edge case scoped
+to unusual setups — it's the default outcome of the single most common
+setup (one env-configured sudo admin managing its own users directly).
+
+**Workaround:** `sdk.user.removeUser()` in `packages/sdk` catches exactly a
+500 from this endpoint and confirms the delete via a follow-up `getUser`
+(expecting 404) before treating it as success — see
+[`TolerantUserApi`](../packages/sdk/src/core/quirks/tolerant-user-api.ts). A
+genuine failure (the follow-up `getUser` shows the user still exists, or
+the confirmation itself can't be made) still throws. The integration
+suite's own `removeUserTolerantly()` in
 [`packages/sdk/test/integration/helpers/quirks.ts`](../packages/sdk/test/integration/helpers/quirks.ts)
 and the mirrored helper in
 [`packages/mcp/test/integration/helpers/quirks.ts`](../packages/mcp/test/integration/helpers/quirks.ts)
-— catches exactly a 500 from `removeUser` and treats it as success.
+now just call `sdk.user.removeUser()` directly — the tolerance itself moved
+into the SDK, and the wrapper only remains to add
+[`freshConnectionConfig()`](../packages/sdk/test/integration/helpers/quirks.ts)
+(a one-off connection), so that the SDK's own internal confirmation call
+doesn't draw the poisoned socket left behind by the crash.
 
-**Open:** the SDK itself does not currently special-case this — a real
-caller of `sdk.user.removeUser()` against an affected Marzban version still
-sees an `HttpError` on a successful delete, and hitting it only requires a
-panel with more than one admin. Tracked in
-[issue #103](https://github.com/Ilmar7786/marzban-sdk/issues/103): whether
-that tolerance belongs in the SDK proper (and, if so, how narrowly to scope
-it so a _genuine_ 500 elsewhere isn't silently swallowed) or stays
-test-only.
+Resolved in [issue #103](https://github.com/Ilmar7786/marzban-sdk/issues/103),
+shipping in `sdk-v3.3.0`.
 
 ## The 500 above can poison the next request on the same connection
 

--- a/packages/mcp/test/integration/helpers/quirks.ts
+++ b/packages/mcp/test/integration/helpers/quirks.ts
@@ -1,19 +1,17 @@
-import { isHttpError, type MarzbanSDK } from 'marzban-sdk'
+import type { MarzbanSDK } from 'marzban-sdk'
 
 import { tlsAgent } from './tls'
 
 // Mirrors packages/sdk/test/integration/helpers/quirks.ts — see
 // docs/marzban-quirks.md for the full writeup of what's worked around here.
+// sdk.user.removeUser() itself absorbs the 500-despite-success quirk now;
+// this wrapper only adds a fresh connection so the internal confirmation
+// doesn't draw the poisoned socket the crash can leave behind.
 
 export function freshConnectionConfig(): Record<string, unknown> {
   return { httpsAgent: tlsAgent() }
 }
 
 export async function removeUserTolerantly(sdk: MarzbanSDK, username: string): Promise<void> {
-  try {
-    await sdk.user.removeUser(username, freshConnectionConfig())
-  } catch (err) {
-    if (isHttpError(err) && err.status === 500) return
-    throw err
-  }
+  await sdk.user.removeUser(username, freshConnectionConfig())
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marzban-sdk",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "description": "The complete TypeScript SDK for the Marzban API — fully typed endpoints, auto token refresh, retries, WebSocket log streaming, webhooks and Zod validation. Isomorphic for Node.js and the browser.",
   "keywords": [
     "marzban-sdk",

--- a/packages/sdk/src/core/MarzbanSDK.ts
+++ b/packages/sdk/src/core/MarzbanSDK.ts
@@ -5,6 +5,7 @@ import { AuthManager } from './auth'
 import { SdkError } from './errors'
 import { configureHttpClient } from './http'
 import { createLogger, Logger } from './logger'
+import { TolerantUserApi } from './quirks/tolerant-user-api'
 import { WebhookManager } from './webhook'
 import { LogsStream } from './ws'
 
@@ -35,6 +36,9 @@ export class MarzbanSDK {
 
   /**
    * User management API endpoints.
+   *
+   * `removeUser` tolerates the Marzban panel-side 500 that follows a
+   * successful delete — see docs/marzban-quirks.md.
    */
   readonly user: userApi
 
@@ -137,7 +141,7 @@ export class MarzbanSDK {
     this.admin = new adminApi({ client: http.client })
     this.core = new coreApi({ client: http.client })
     this.node = new nodeApi({ client: http.client })
-    this.user = new userApi({ client: http.client })
+    this.user = new TolerantUserApi({ client: http.client })
     this.system = new systemApi({ client: http.client })
     this.subscription = new subscriptionApi({ client: http.client })
     this.userTemplate = new userTemplateApi({ client: http.client })

--- a/packages/sdk/src/core/quirks/tolerant-user-api.test.ts
+++ b/packages/sdk/src/core/quirks/tolerant-user-api.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AnyType } from '@/common'
+
+import { HttpError } from '../errors'
+import { TolerantUserApi } from './tolerant-user-api'
+
+// A minimal userResponseSchema-valid payload — only used to make a
+// successful getUser() call resolve without a schema-validation error.
+const EXISTING_USER = {
+  proxies: {},
+  username: 'orphantest',
+  status: 'active',
+  used_traffic: 0,
+  created_at: '2026-01-01T00:00:00',
+}
+
+function httpError(status: number): HttpError {
+  return new HttpError({ response: { status } })
+}
+
+function mockClient(): AnyType {
+  return vi.fn()
+}
+
+describe('TolerantUserApi', () => {
+  it('returns the response as-is when removeUser succeeds directly', async () => {
+    const client = mockClient()
+    client.mockResolvedValueOnce({ data: { detail: 'User successfully deleted' } })
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('someuser')).resolves.toEqual({ detail: 'User successfully deleted' })
+    expect(client).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows a non-500 HttpError without confirming via getUser', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(404))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('someuser')).rejects.toMatchObject({ status: 404 })
+    expect(client).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows a non-HttpError without confirming via getUser', async () => {
+    const networkError = new Error('socket hang up')
+    const client = mockClient()
+    client.mockRejectedValueOnce(networkError)
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('someuser')).rejects.toBe(networkError)
+    expect(client).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a 500 as success once a follow-up getUser confirms 404', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockRejectedValueOnce(httpError(404))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).resolves.toEqual({ detail: 'User successfully deleted' })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original 500 when the follow-up getUser shows the user still exists', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockResolvedValueOnce({ data: EXISTING_USER })
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).rejects.toMatchObject({ status: 500 })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original 500 when the follow-up getUser fails with a non-404 HttpError', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockRejectedValueOnce(httpError(401))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).rejects.toMatchObject({ status: 500 })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows the original 500 when the follow-up getUser fails with a non-HttpError', async () => {
+    const client = mockClient()
+    client.mockRejectedValueOnce(httpError(500)).mockRejectedValueOnce(new Error('socket hang up'))
+    const api = new TolerantUserApi({ client })
+
+    await expect(api.removeUser('orphantest')).rejects.toMatchObject({ status: 500 })
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/sdk/src/core/quirks/tolerant-user-api.ts
+++ b/packages/sdk/src/core/quirks/tolerant-user-api.ts
@@ -1,0 +1,42 @@
+import type { Client, RequestConfig } from '@kubb/plugin-client/clients/axios'
+
+import { userApi } from '@/gen/api'
+import type { RemoveUserPathParams } from '@/gen/models/UserModel/RemoveUser'
+
+import { isHttpError } from '../errors'
+
+/**
+ * `userApi` with the `DELETE /api/user/{username}` 500-despite-success quirk
+ * absorbed — see docs/marzban-quirks.md. Marzban deletes the user, then
+ * crashes building an unrelated deletion report before it can send the
+ * response. A 500 from `removeUser` is only treated as success once a
+ * follow-up `getUser` confirms the user is actually gone (404) — a genuine
+ * failure (user still exists, or the confirmation itself can't be made)
+ * still throws the original error.
+ */
+export class TolerantUserApi extends userApi {
+  async removeUser(
+    username: RemoveUserPathParams['username'],
+    config: Partial<RequestConfig> & { client?: Client } = {}
+  ) {
+    try {
+      return await super.removeUser(username, config)
+    } catch (err) {
+      if (!isHttpError(err) || err.status !== 500) throw err
+      if (await this.stillExists(username, config)) throw err
+      return { detail: 'User successfully deleted' }
+    }
+  }
+
+  private async stillExists(
+    username: RemoveUserPathParams['username'],
+    config: Partial<RequestConfig> & { client?: Client }
+  ): Promise<boolean> {
+    try {
+      await this.getUser(username, config)
+      return true
+    } catch (err) {
+      return !(isHttpError(err) && err.status === 404)
+    }
+  }
+}

--- a/packages/sdk/test/integration/helpers/quirks.ts
+++ b/packages/sdk/test/integration/helpers/quirks.ts
@@ -1,4 +1,4 @@
-import { isHttpError, type MarzbanSDK } from '../../../src/index'
+import type { MarzbanSDK } from '../../../src/index'
 import { tlsAgent } from './tls'
 
 // Real Marzban panel behavior worked around below — see
@@ -19,18 +19,15 @@ export function freshConnectionConfig(): Record<string, unknown> {
 }
 
 /**
- * `removeUser` reliably rejects with a 500 even when the delete succeeded
- * (docs/marzban-quirks.md: "DELETE /api/user/{username} 500s despite
- * deleting the user"). Use this wherever a test needs to actually remove a
- * user (cleanup or the delete test itself); verify the outcome via a
- * follow-up `getUser` 404 (with {@link freshConnectionConfig}), not via
- * this resolving.
+ * `sdk.user.removeUser()` itself now absorbs the panel's 500-despite-success
+ * quirk (docs/marzban-quirks.md: "DELETE /api/user/{username} 500s despite
+ * deleting the user"), confirming via its own follow-up `getUser` before
+ * treating a 500 as success. This wrapper only adds
+ * {@link freshConnectionConfig} — a one-off connection, so that internal
+ * confirmation (and any later call reusing the pool) doesn't draw the
+ * poisoned socket the crash can leave behind. Use this wherever a test needs
+ * to actually remove a user (cleanup or the delete test itself).
  */
 export async function removeUserTolerantly(sdk: MarzbanSDK, username: string): Promise<void> {
-  try {
-    await sdk.user.removeUser(username, freshConnectionConfig())
-  } catch (err) {
-    if (isHttpError(err) && err.status === 500) return
-    throw err
-  }
+  await sdk.user.removeUser(username, freshConnectionConfig())
 }


### PR DESCRIPTION
## Summary

- `DELETE /api/user/{username}` reliably 500s in Marzban when the deleted user's `admin_id` doesn't resolve to a live `Admin` row — most commonly, any user created directly by the env-configured sudo admin, which has no row in the `admins` table at all. The delete already succeeded server-side; only the HTTP response is lost. See `docs/marzban-quirks.md` for the full writeup and root cause, verified against a freshly recreated `local/marzban/` container and confirmed unfixed on upstream `master`.
- `sdk.user` is now backed by `TolerantUserApi` (`packages/sdk/src/core/quirks/tolerant-user-api.ts`), a hand-written subclass of the generated `userApi` (never editing `src/gen/`, which codegen overwrites). `removeUser()` catches exactly a 500, confirms via a follow-up `getUser()` (expecting 404), and only then returns a synthetic success — a genuine failure (user still exists, or the confirmation itself can't be made) still throws the original error unchanged.
- `removeUserTolerantly()` in both packages' integration test helpers now just calls `sdk.user.removeUser()` directly — the tolerance moved into the SDK, and the wrapper only remains for `freshConnectionConfig()` (avoiding the separately-documented poisoned-connection quirk on the confirmation call).
- Closes #103.

## Test plan

- [x] New unit tests for `TolerantUserApi` covering all branches (direct success, non-500 error, non-`HttpError`, 500-confirmed-404, 500-still-exists, 500-confirmation-fails-differently)
- [x] `pnpm test:coverage` — 100% statements/branches/functions/lines maintained
- [x] `pnpm types:check` and `pnpm lint` clean in both `sdk` and `mcp`
- [x] Live end-to-end verification against a freshly recreated `local/marzban/` container reproducing the real scenario — `sdk.user.removeUser()` resolves instead of throwing, and a follow-up `getUser()` correctly still 404s