### PR TITLE
docs(docs): rewrite contributing and FAQ for the pnpm monorepo

### DIFF
--- a/apps/docs/content/docs/openapi/patches.mdx
+++ b/apps/docs/content/docs/openapi/patches.mdx
@@ -3,7 +3,7 @@ title: Spec Patches
 description: Patches applied on top of upstream Marzban's OpenAPI spec, and why — so you know when a type differs from what the panel actually returns.
 ---
 
-MarzbanSDK vendors `openapi/openapi.json` in the repository instead of fetching Marzban's spec at build time (see [ADR-0003](https://github.com/Ilmar7786/marzban-sdk/blob/main/docs/adr/0003-vendored-openapi-spec.md)), and hand-patches schemas that upstream leaves under-specified. Every patch currently applied is listed here.
+MarzbanSDK vendors `packages/sdk/openapi/openapi.json` in the repository instead of fetching Marzban's spec at build time (see [ADR-0003](https://github.com/Ilmar7786/marzban-sdk/blob/main/docs/adr/0003-vendored-openapi-spec.md)), and hand-patches schemas that upstream leaves under-specified. Every patch currently applied is listed here.
 
 ## Under-specified schemas no longer drop fields on parse
 
@@ -21,5 +21,5 @@ Several upstream schemas are declared as `type: object` with no `properties` —
 | `CoreConfig` (put) | `PUT /api/core/config` |
 
 <Callout type="info">
-  Pinned by [`gen-regression.test.ts`](https://github.com/Ilmar7786/marzban-sdk/blob/main/packages/sdk/src/gen-regression.test.ts) — a future `pnpm codegen` run that reverts this fails the test suite instead of shipping silently-truncated data.
+  Pinned by [`gen-regression.test.ts`](https://github.com/Ilmar7786/marzban-sdk/blob/main/packages/sdk/src/gen-regression.test.ts) — a future `pnpm --filter marzban-sdk codegen` run that reverts this fails the test suite instead of shipping silently-truncated data.
 </Callout>

--- a/apps/docs/content/docs/openapi/spec.mdx
+++ b/apps/docs/content/docs/openapi/spec.mdx
@@ -4,7 +4,7 @@ description: The exact schema MarzbanSDK is generated from — patched where ups
 full: true
 ---
 
-MarzbanSDK doesn't fetch Marzban's OpenAPI spec at build time — it vendors a copy in the repository (`packages/sdk/openapi/openapi.json`) and hand-patches the parts upstream leaves under-specified. A future `npm run codegen` run can still overwrite those patches; [`gen-regression.test.ts`](https://github.com/Ilmar7786/marzban-sdk/blob/main/packages/sdk/src/gen-regression.test.ts) is what catches that, by pinning the generated behavior the patches produce.
+MarzbanSDK doesn't fetch Marzban's OpenAPI spec at build time — it vendors a copy in the repository (`packages/sdk/openapi/openapi.json`) and hand-patches the parts upstream leaves under-specified. A future `pnpm --filter marzban-sdk codegen` run can still overwrite those patches; [`gen-regression.test.ts`](https://github.com/Ilmar7786/marzban-sdk/blob/main/packages/sdk/src/gen-regression.test.ts) is what catches that, by pinning the generated behavior the patches produce.
 
 <OpenApiViewer />
 

--- a/apps/docs/content/docs/resources/contributing.mdx
+++ b/apps/docs/content/docs/resources/contributing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-description: How to contribute to MarzbanSDK — reporting bugs, submitting PRs, and development setup.
+description: How to contribute to MarzbanSDK — reporting bugs, submitting PRs, and development setup in the pnpm/Turborepo monorepo.
 ---
 
 Thank you for your interest in contributing to MarzbanSDK! All contributions are welcome — bug fixes, features, documentation improvements, and test coverage.
@@ -12,49 +12,104 @@ Open an issue on [GitHub](https://github.com/Ilmar7786/marzban-sdk/issues) and i
 - A clear description of the problem.
 - Steps to reproduce (code snippet or minimal repo link preferred).
 - Expected vs. actual behaviour.
-- SDK version (`npm list marzban-sdk`).
+- The SDK version you're on and the package it's in (`marzban-sdk`, `marzban-mcp`, ...).
+
+## Repository layout
+
+MarzbanSDK is a monorepo managed with [pnpm workspaces](https://pnpm.io/workspaces) and [Turborepo](https://turbo.build/repo):
+
+| Path | Package | What it is |
+|---|---|---|
+| `packages/sdk` | `marzban-sdk` | The SDK itself. Published to npm. |
+| `packages/mcp` | `marzban-mcp` | MCP server built on top of the SDK. Published to npm, Docker Hub, and the MCP Registry. |
+| `packages/cli` | `marzban-cli` | Command-line interface. Still an unpublished work in progress. |
+| `apps/docs` | `marzban-sdk-docs` | This documentation site. |
 
 ## Development setup
+
+You'll need **Node ≥ 24** and **pnpm 11** (the exact version is pinned in the root `package.json`'s `packageManager` field — run any `pnpm` command and Corepack will fetch it automatically).
 
 ```bash
 git clone https://github.com/Ilmar7786/marzban-sdk.git
 cd marzban-sdk
-npm install
+pnpm install
+pnpm build && pnpm test
 ```
 
 ### Available scripts
 
+Run from the repo root, these fan out across the workspace via Turborepo:
+
 | Command | Description |
 |---------|-------------|
-| `npm run build` | Compile TypeScript → `dist/` (ESM + CJS) |
-| `npm test` | Run the full test suite once with Vitest |
-| `npm run test:watch` | Run tests in watch mode |
-| `npm run test:coverage` | Run tests with a coverage report |
-| `npm run lint` | Run ESLint |
-| `npm run codegen` | Regenerate the API client from `openapi/` using Kubb |
+| `pnpm build` | Build all packages |
+| `pnpm test` | Run the unit test suite for every package |
+| `pnpm lint` | Run ESLint across the workspace |
+| `pnpm lint:fix` | Run ESLint with `--fix` |
+| `pnpm types:check` | Type-check every package with `tsc --noEmit` |
+| `pnpm format` | Format the repo with Prettier |
+| `pnpm format:check` | Check formatting without writing |
+
+Package-specific scripts need `--filter`:
+
+| Command | Description |
+|---------|-------------|
+| `pnpm --filter marzban-sdk test:watch` | Watch mode while developing |
+| `pnpm --filter marzban-sdk test:coverage` | Run tests with a coverage report |
+| `pnpm --filter marzban-sdk test:integration` | Run integration tests against a real panel |
+| `pnpm --filter marzban-sdk codegen` | Regenerate the API client from the OpenAPI spec |
+| `pnpm --filter marzban-sdk dev` | Build in watch mode |
+
+<Callout type="info">
+  There's no root-level `codegen` script — it only exists on `packages/sdk`, so it always needs `--filter marzban-sdk` (or `pnpm turbo run codegen`).
+</Callout>
+
+### Local Marzban panel
+
+To try changes against a real Marzban panel, spin up a disposable one in Docker:
+
+```bash
+pnpm local:up     # start
+pnpm local:logs   # follow logs
+pnpm local:down   # stop
+pnpm local:reset  # stop and wipe data
+```
+
+See [`local/README.md`](https://github.com/Ilmar7786/marzban-sdk/blob/main/local/README.md) for details. This is also what the integration test suite runs against.
 
 ## Testing
 
-The SDK is covered by [Vitest](https://vitest.dev). Tests live next to the code they cover as `src/**/*.test.ts`.
+The SDK and MCP server are covered by [Vitest](https://vitest.dev). Unit tests live next to the code they cover, as `src/**/*.test.ts`.
 
 ```bash
-npm test              # run once
-npm run test:watch    # watch mode while developing
-npm run test:coverage # run with a coverage report
+pnpm --filter marzban-sdk test              # run once
+pnpm --filter marzban-sdk test:watch        # watch mode while developing
+pnpm --filter marzban-sdk test:coverage     # run with a coverage report
 ```
 
-Hand-written code is held at **100% coverage** — statements, branches, functions, and lines. Generated code (`src/gen/`, produced from the OpenAPI spec) and type-only files are excluded from coverage on purpose.
+Hand-written code is held at **100% coverage** — statements, branches, functions, and lines — in both `packages/sdk` and `packages/mcp`. Generated code (`src/gen/**`), type-only files (`**/types.ts`, `**/*.types.ts`), and barrel files (`**/index.ts`) are excluded from coverage on purpose.
 
-Every feature and bug fix must come with tests, and `npm run test:coverage` must stay green.
+Every feature and bug fix must come with tests, and `pnpm --filter marzban-sdk test:coverage` must stay green.
+
+Integration tests are separate — `test/integration/**/*.integration.test.ts`, run with their own config against a real panel:
+
+```bash
+pnpm local:up
+pnpm --filter marzban-sdk test:integration
+pnpm --filter marzban-mcp test:integration
+```
+
+They don't run as part of `pnpm test` and aren't held to the coverage threshold.
 
 ### Build & verify
 
 ```bash
-npm run build
-npm run test:coverage
+pnpm build
+pnpm test
+pnpm types:check
 ```
 
-Both must pass before submitting a PR.
+All three must pass before submitting a PR.
 
 ## Submitting a pull request
 
@@ -63,15 +118,19 @@ Both must pass before submitting a PR.
    git checkout -b feat/your-feature
    ```
 2. Make your changes.
-3. Add or update tests in `src/**/*.test.ts`.
-4. Run `npm run test:coverage` and `npm run build`.
+3. Add or update tests next to the code they cover (`src/**/*.test.ts`).
+4. Run `pnpm test` and `pnpm build`.
 5. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitlint):
    ```
    feat: add pagination to getUsers
    fix: handle missing token in AuthManager
    docs: add NestJS integration example
    ```
-6. Push and open a PR against the `main` branch.
+6. Push and open a PR against the **`dev`** branch.
+
+<Callout type="warn">
+  PRs target `dev`, not `main`. `dev` is the integration branch — it merges into `main` periodically. Both branches require the `ci` check to pass.
+</Callout>
 
 ## Commit message format
 
@@ -83,28 +142,53 @@ Optional body.
 BREAKING CHANGE: description  ← for major version bumps
 ```
 
-**Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `build`.
+**Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `build`, `ci`.
+
+**Scopes:** `sdk`, `cli`, `mcp`, `docs`, `deps`, `ci`, `release`, `changelog`. A scope can be a comma-separated list — if a fix in `packages/sdk` also changes `marzban-mcp`'s behaviour, scope it `fix(sdk,mcp): ...` so it surfaces in mcp's changelog too.
+
+A Husky `pre-commit` hook runs `lint-staged` (ESLint + Prettier on staged files), and `commit-msg` runs commitlint against these rules.
 
 ## Code style
 
 - All code is in **TypeScript** with `strict` mode enabled.
-- ESLint + Prettier enforce style — run `npm run lint` before committing.
-- No unnecessary `any` — prefer proper generics or `unknown`.
+- ESLint + Prettier enforce style — run `pnpm lint` before committing.
+- No unnecessary `any` type — prefer proper generics or `unknown`.
 - No comments that explain *what* the code does — only *why* when it's non-obvious.
+- MDX content under `apps/docs/content/` is excluded from Prettier and formatted by hand — Prettier's MDX printer can mangle fenced code blocks inside JSX.
 
 ## Regenerating the API client
 
-The `src/gen/` directory is auto-generated from the OpenAPI spec. Do **not** edit it manually:
+`packages/sdk/src/gen/` is auto-generated from the OpenAPI spec by [kubb](https://kubb.dev). Do **not** edit it manually — a fresh generation wipes the directory clean:
 
 ```bash
-# Update the spec in openapi/ first, then:
-npm run codegen
+# Update packages/sdk/openapi/openapi.json first, then:
+pnpm --filter marzban-sdk codegen
 ```
 
 If you're fixing a bug in a generated file, fix the template or the spec instead.
 
-Some schemas in `openapi/openapi.json` are hand-patched on top of what upstream Marzban publishes — see [Spec Patches](/docs/openapi/patches) before touching them, and add a regression test alongside any new patch.
+Some schemas in `packages/sdk/openapi/openapi.json` are hand-patched on top of what upstream Marzban publishes — see [Spec Patches](/docs/openapi/patches) before touching them, and add a regression test alongside any new patch.
+
+## CI
+
+Every PR against `main` or `dev` runs on Node 24:
+
+```bash
+pnpm turbo run lint types:check test build
+pnpm format:check
+```
+
+Reproduce it locally with the same two commands. A separate `integration` workflow runs the integration suites against a Docker panel — it's informational and doesn't block merging.
+
+## Releases
+
+There's no manual tagging. A release is triggered by a `version` bump in a package's `package.json` landing on `main`: [git-cliff](https://git-cliff.org) generates the changelog, and a GitHub Release creates the tag (`sdk-v*`, `mcp-v*`), which publishes to npm. Preview the changelog for a pending bump locally:
+
+```bash
+pnpm changelog:sdk
+pnpm changelog:mcp
+```
 
 ## Questions
 
-Start a discussion in [GitHub Discussions](https://github.com/Ilmar7786/marzban-sdk/discussions) or open an issue.
+Start a discussion in [GitHub Discussions](https://github.com/Ilmar7786/marzban-sdk/discussions) or open an issue. For how the workspace, CI, and releases actually work under the hood, [`docs/`](https://github.com/Ilmar7786/marzban-sdk/blob/main/docs/README.md) in the repository is the canonical source.

--- a/apps/docs/content/docs/resources/faq.mdx
+++ b/apps/docs/content/docs/resources/faq.mdx
@@ -1,13 +1,15 @@
 ---
 title: FAQ
-description: Answers to common MarzbanSDK questions — Marzban version support, browser and runtime compatibility, authentication, token refresh, and webhooks.
+description: Answers to common MarzbanSDK questions — Marzban version support, runtime compatibility, authentication, retries, error handling, and webhooks.
 ---
+
+Answers to questions that come up repeatedly across issues and discussions. If yours isn't here, check the rest of the docs or [open a discussion](https://github.com/Ilmar7786/marzban-sdk/discussions).
 
 ## General
 
 ### What version of Marzban does this SDK support?
 
-MarzbanSDK v3.x is generated from the Marzban API as of **v0.8.4** — that's the version pinned in the bundled OpenAPI specification (`packages/sdk/openapi/openapi.json`, `info.version`; browse it on the [OpenAPI Spec](/docs/openapi/spec) page). Newer Marzban releases that are additive (new optional fields, new endpoints) generally keep working; a release that changes existing request/response shapes may not, until the spec is re-vendored and the client regenerated. Check the [Changelog](/docs/resources/changelog) for what changed between SDK versions.
+MarzbanSDK v3.x is generated from the Marzban API as of **v0.8.4** — that's the version pinned in the bundled OpenAPI specification (`packages/sdk/openapi/openapi.json`, `info.version`; browse it on the [OpenAPI Spec](/docs/openapi/spec) page). A handful of schemas are hand-patched on top of what upstream publishes — see [Spec Patches](/docs/openapi/patches). Newer Marzban releases that are additive (new optional fields, new endpoints) generally keep working; a release that changes existing request/response shapes may not, until the spec is re-vendored and the client regenerated. Check the [Changelog](/docs/resources/changelog) for what changed between SDK versions.
 
 ### Does it work in the browser?
 
@@ -15,11 +17,24 @@ Yes, for most features. The SDK is designed to be cross-runtime:
 
 - **API calls** — work in any environment.
 - **WebSocket log streaming** — works in browsers using the native `WebSocket` global.
-- **Webhook signature verification** — **server-side only**. Calling `handleWebhook` or `parseWebhook` with a secret in a browser throws `WebhookEnvironmentError` to prevent secret exposure.
+- **Webhook signature verification** — **server-side only**. Calling `handleWebhook` or `parseWebhook` with `webhook.secret` configured, or calling `verifyWebhookSignature` directly, in a browser throws `WebhookEnvironmentError` to prevent secret exposure. Without a secret configured, `handleWebhook`/`parseWebhook` work fine in a browser — there's simply nothing to verify.
 
-### Can I use the SDK without TypeScript?
+The browser check looks for both `window` and `document`, so Web Workers, Deno, Bun, and edge runtimes are treated as server-side and aren't affected.
 
-Yes. The package ships ESM and CJS bundles that work in plain JavaScript. You'll lose autocomplete and type checking, but the runtime behaviour is identical.
+### What Node.js version do I need?
+
+The published packages don't declare an `engines` field, but two features have real runtime floors:
+
+| Feature | Requirement |
+|---|---|
+| Webhook signature verification (`crypto.subtle`) | Node 19+ |
+| Native `WebSocket` log streaming | Node 21+ (older versions fall back to the bundled `ws` package) |
+
+Bun, Deno, and browsers are supported throughout. `Node >= 24` is only required to *develop* the SDK itself — see [Contributing](/docs/resources/contributing).
+
+### SDK or `marzban-mcp` — which do I want?
+
+Use `marzban-sdk` directly if you're writing your own TypeScript/JavaScript application. Use [`marzban-mcp`](/docs/mcp-server/overview) if you want an AI assistant (Claude, or anything else that speaks MCP) to manage your Marzban panel — it's an MCP server built on top of this SDK.
 
 ### My self-hosted panel uses a self-signed certificate — how do I connect?
 
@@ -37,9 +52,9 @@ const sdk = await createMarzbanSDK({
 })
 ```
 
-See [Self-signed certificates & custom CA](/docs/configuration/config-options#self-signed-certificates--custom-ca). Using `marzban-mcp` instead? Set `MARZBAN_TLS_CA_FILE` — see [MCP Configuration](/docs/mcp-server/configuration#tls--self-signed-certificates).
+There's also an `httpAgent` counterpart for plain HTTP. Both are typed structurally (anything with a `destroy()` method), so proxy agents like `https-proxy-agent` or `socks-proxy-agent` work too.
 
----
+See [Self-signed certificates & custom CA](/docs/configuration/config-options#self-signed-certificates--custom-ca). Using `marzban-mcp` instead? Set `MARZBAN_TLS_CA_FILE` — see [MCP Configuration](/docs/mcp-server/configuration#tls--self-signed-certificates).
 
 ## Authentication
 
@@ -49,13 +64,26 @@ No — `createMarzbanSDK` calls it automatically by default. Set `authenticateOn
 
 ### What happens when the JWT expires?
 
-The SDK catches `401 Unauthorized` responses, re-authenticates with your stored `username` and `password`, and retries the original request transparently. You don't need to handle this in your code.
+The SDK catches `401 Unauthorized` responses, re-authenticates with your stored `username` and `password`, and retries the original request transparently — once. If the retried request also comes back `401`, that error propagates to your code instead of retrying indefinitely.
 
 ### Can I use a pre-existing token?
 
-Yes. Pass it via the `token` config field. The SDK will use it until it expires, then fall back to credentials for renewal.
+Yes, via the `token` config field — but two things trip people up:
 
----
+- `username` and `password` are still required even when you pass `token`. There's no token-only mode.
+- With the default `authenticateOnInit: true`, `createMarzbanSDK` logs in immediately and **overwrites** the token you passed. Pair `token` with `authenticateOnInit: false` if you want it actually used:
+
+```ts
+const sdk = await createMarzbanSDK({
+  baseUrl: 'https://panel.example.com',
+  username: 'admin',
+  password: 'secret',
+  token: existingToken,
+  authenticateOnInit: false,
+})
+```
+
+The SDK will use `token` until it expires, then fall back to `username`/`password` for renewal.
 
 ## Errors
 
@@ -75,13 +103,19 @@ try {
 }
 ```
 
-See [Error Handling](/docs/advanced/error-handling) for the full list.
+There are nine guards in total, one per error class. See [Error Handling](/docs/advanced/error-handling) for the full list.
 
-### What does AUTH_TOKEN_FAILED mean?
+### What does `AUTH_TOKEN_FAILED` mean?
 
 The server returned `200 OK` from the login endpoint, but the response body contained no `access_token`. This usually means the Marzban API returned an unexpected response format. Check your Marzban version compatibility.
 
----
+### Will my password end up in the logs?
+
+No. `SdkError` redacts known secret keys — `authorization`, `password`, `token`, `secret`, `apikey`, `cookie`, and similar — replacing their values with `[REDACTED]` in `.details`, `.toJSON()`, and anything the built-in logger prints. WebSocket URLs have their `token=` query parameter stripped before logging, too.
+
+### Why wasn't my failed `createUser` call retried?
+
+Only `GET`, `HEAD`, and `OPTIONS` requests are retried automatically, and only on network errors or `429`/`5xx` responses. `POST`, `PUT`, `PATCH`, and `DELETE` are never retried — even on a network error — because re-sending a request whose outcome is unknown could duplicate a write. See [HTTP & Retry](/docs/advanced/http-retry).
 
 ## Webhooks
 
@@ -91,42 +125,38 @@ You don't have to, but you should in production. Without signature verification,
 
 ### Why does signature verification throw WebhookEnvironmentError?
 
-Webhook signature verification uses `crypto.subtle` (Web Crypto API). While this API is available in browsers, running signature verification in a browser would require exposing your webhook secret to the client. The SDK detects the browser environment and throws `WebhookEnvironmentError` to prevent this mistake.
+Webhook signature verification uses `crypto.subtle` (Web Crypto API). While this API is available in browsers, running signature verification in a browser would require exposing your webhook secret to the client. The SDK detects the browser environment and throws `WebhookEnvironmentError` to prevent this mistake — this only applies when a secret is configured; without one there's nothing to verify.
+
+### Why do I get "Raw body required for signature verification"?
+
+When `webhook.secret` is configured, `parseWebhook` needs the **raw, unparsed** request body (`string`, `Uint8Array`, or `ArrayBuffer`) plus the signature header to verify it — an already-JSON-parsed object can't be verified, so it throws `WebhookSignatureError`. Read the raw body from your framework before parsing it yourself; see the framework-specific webhook guides for examples.
 
 ### Can Marzban send multiple events in one request?
 
-Yes. The `handleWebhook` method processes arrays of events. Subscribe to the `'batch'` event to receive the full array in one call.
-
----
+Yes. `handleWebhook` processes arrays of events. Subscribe to the `'batch'` event to receive the full array in one call, or `'*'` to receive every event regardless of action. `handleWebhook` awaits your listeners before resolving, so `await`ing it guarantees processing finished before you respond to the request.
 
 ## Utilities
 
 ### Is parseSize case-sensitive?
 
-No. It accepts `GB`, `gb`, `Gb`, `GiB`, etc. The value is normalised to uppercase internally.
+No. It accepts `GB`, `gb`, `Gb`, `GiB`, etc. The value is normalised to uppercase internally. By default it uses binary units (1 GB = 1024³ bytes); pass `{ decimal: true }` for decimal (1000-based) units. Unparseable input returns `0` rather than throwing.
 
 ### What does humanRemaining return for expired dates?
 
-It returns the string `"expired"` when `totalMs < 0` (i.e. the date is in the past).
+It returns the string `"expired"` when `totalMs < 0` (i.e. the date is in the past), and `"< 1s"` when the remaining time rounds down to nothing.
 
----
+### Is there a cache, or client-side rate limiting?
+
+No. MarzbanSDK doesn't cache responses or throttle outgoing requests on its own — every call hits the panel directly. If you need either, add it in your application layer.
 
 ## Development
 
-### How do I run the tests?
+See [Contributing](/docs/resources/contributing) for the full setup. In short, this is a pnpm/Turborepo monorepo — the SDK lives in `packages/sdk`:
 
 ```bash
-npm test
+pnpm --filter marzban-sdk test        # run the test suite
+pnpm --filter marzban-sdk build       # build the package
+pnpm --filter marzban-sdk codegen     # regenerate the API client
 ```
 
-The test suite uses **Vitest** and covers config validation, auth flow, error classes, webhook parsing, and utility functions.
-
-### How do I regenerate the API client?
-
-The generated code in `src/gen/` is produced by Kubb from the OpenAPI spec in `openapi/`:
-
-```bash
-npm run codegen
-```
-
-After regenerating, rebuild with `npm run build`.
+The generated code in `packages/sdk/src/gen/` is produced by Kubb from the OpenAPI spec at `packages/sdk/openapi/openapi.json`. After regenerating, rebuild with `pnpm --filter marzban-sdk build`.


### PR DESCRIPTION
Both pages still described the old single-package npm setup. Now they match the pnpm/Turborepo workspace: correct commands, PRs against dev, coverage rules, and a handful of FAQ answers for 3.1-3.3 features that weren't covered (retries, secret redaction, runtime requirements).