### PR TITLE
chore(mcp): add glama.json metadata

### DIFF
--- a/packages/mcp/glama.json
+++ b/packages/mcp/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Ilmar7786"]
+}


### PR DESCRIPTION
## Summary
- Adds `packages/mcp/glama.json` declaring the GitHub maintainer for the marzban-mcp Glama listing, closing the "No glama.json" item on the server's Glama score checklist.

## Test plan
- [x] Validates against https://glama.ai/mcp/schemas/server.json