### PR TITLE
docs: mention Glama listing in MCP server overview

### DIFF
--- a/apps/docs/content/docs/mcp-server/overview.mdx
+++ b/apps/docs/content/docs/mcp-server/overview.mdx
@@ -38,7 +38,7 @@ It's a separate package from the SDK itself. If you're building your own integra
 }
 ```
 
-Nearly every MCP client reads this same shape — see [Client Setup](/docs/mcp-server/client-setup) for exact instructions per client. Prefer a container over Node.js on the host? A multi-arch image is published at [`ilmar7786/marzban-mcp`](https://hub.docker.com/r/ilmar7786/marzban-mcp) — see [Client Setup → Running via Docker](/docs/mcp-server/client-setup#running-via-docker). Also listed in the official [MCP Registry](https://registry.modelcontextprotocol.io/?q=marzban-mcp) as `io.github.Ilmar7786/marzban-mcp` — verified via GitHub ownership.
+Nearly every MCP client reads this same shape — see [Client Setup](/docs/mcp-server/client-setup) for exact instructions per client. Prefer a container over Node.js on the host? A multi-arch image is published at [`ilmar7786/marzban-mcp`](https://hub.docker.com/r/ilmar7786/marzban-mcp) — see [Client Setup → Running via Docker](/docs/mcp-server/client-setup#running-via-docker). Also listed in the official [MCP Registry](https://registry.modelcontextprotocol.io/?q=marzban-mcp) as `io.github.Ilmar7786/marzban-mcp` — verified via GitHub ownership — and on [Glama](https://glama.ai/mcp/servers/Ilmar7786/marzban-sdk) [![marzban-mcp MCP server](https://glama.ai/mcp/servers/Ilmar7786/marzban-sdk/badges/score.svg)](https://glama.ai/mcp/servers/Ilmar7786/marzban-sdk), where you can inspect the tool schemas or try the server in a hosted sandbox before installing anything locally.
 
 <Cards>
   <Card title="Client Setup" href="/docs/mcp-server/client-setup" description="Claude, Cursor, Cline, Windsurf, Continue.dev, VS Code" />


### PR DESCRIPTION
## Summary
- Adds one sentence to `mcp-server/overview.mdx`, next to the existing MCP Registry mention, linking to the Glama listing (with score badge) so readers can inspect tool schemas or try the server in a hosted sandbox before installing.
- Kept out of `ai-tools/` — that section is specifically about AI reading *this documentation* (context7, llms.txt); Glama is a registry/discovery listing for the server itself, same category as the existing npm/Docker/MCP Registry mentions.

## Test plan
- [x] Renders as a normal markdown link + badge image, consistent with existing MCP Registry sentence