### PR TITLE
feat(sdk): make destroy() a terminal, idempotent lifecycle transition

### DIFF
--- a/apps/docs/content/docs/advanced/error-handling.mdx
+++ b/apps/docs/content/docs/advanced/error-handling.mdx
@@ -14,6 +14,7 @@ Error
     │   └── AuthTokenError   (code: AUTH_TOKEN_FAILED)
     ├── ConfigurationError   (code: CONFIG_INVALID)
     ├── HttpError            (code: NETWORK_HTTP_ERROR)
+    ├── SdkDestroyedError    (code: SDK_DESTROYED)
     ├── WsOptionsError       (code: WS_OPTIONS_INVALID)
     └── WebhookError
         ├── WebhookSignatureError     (code: WEBHOOK_SIGNATURE_ERROR)
@@ -47,6 +48,7 @@ class SdkError extends Error {
 | `AUTH_TOKEN_FAILED` | `AuthTokenError` | Server responded but returned no `access_token` |
 | `CONFIG_INVALID` | `ConfigurationError` | Config fails Zod schema validation |
 | `NETWORK_HTTP_ERROR` | `HttpError` | HTTP request failed (4xx, 5xx, network timeout) |
+| `SDK_DESTROYED` | `SdkDestroyedError` | A guarded operation (`authorize()`, `logs.connect*()`, webhook processing, …) was called after [`sdk.destroy()`](/docs/advanced/lifecycle) |
 | `WS_OPTIONS_INVALID` | `WsOptionsError` | `LogOptions.interval` is outside the `0`–`10` range the panel accepts |
 | `WEBHOOK_SIGNATURE_ERROR` | `WebhookSignatureError` | Missing signature or HMAC mismatch |
 | `WEBHOOK_VALIDATION_ERROR` | `WebhookValidationError` | Webhook payload doesn't match expected schema |
@@ -79,6 +81,7 @@ import {
   isAuthTokenError,
   isConfigurationError,
   isHttpError,
+  isSdkDestroyedError,
   isWebhookSignatureError,
   isWebhookValidationError,
   isWebhookEnvironmentError,
@@ -175,3 +178,4 @@ try {
 - **Always re-throw unknown errors** — only catch what you can handle; let the rest propagate.
 - **Use `toJSON()`** when logging errors to structured log systems — it serializes the full error context.
 - **Webhook errors are server-side only** — `WebhookEnvironmentError` is thrown if signature verification is called in a browser. Move webhook handling to a server route.
+- **`SdkDestroyedError` means the instance is gone, not that the request was bad** — see [Lifecycle & shutdown](/docs/advanced/lifecycle) for exactly which operations reject after `destroy()`.

--- a/apps/docs/content/docs/advanced/http-retry.mdx
+++ b/apps/docs/content/docs/advanced/http-retry.mdx
@@ -100,10 +100,10 @@ const sdkB = await createMarzbanSDK({ baseUrl: 'https://server-b.com', ... })
 
 ## Cleanup
 
-Call `sdk.destroy()` to close all active WebSocket connections and release resources:
+Call `sdk.destroy()` to release everything the SDK owns — active WebSocket connections, webhook listeners, the stored token — and enter a terminal, idempotent shutdown state:
 
 ```ts
 await sdk.destroy()
 ```
 
-This is particularly important in long-running processes or tests where you create multiple SDK instances.
+This is particularly important in long-running processes or tests where you create multiple SDK instances. See [Lifecycle & shutdown](/docs/advanced/lifecycle) for the full `destroy()` contract, including which operations reject afterward.

--- a/apps/docs/content/docs/advanced/lifecycle.mdx
+++ b/apps/docs/content/docs/advanced/lifecycle.mdx
@@ -1,0 +1,80 @@
+---
+title: Lifecycle & Shutdown
+description: What `sdk.destroy()` guarantees — idempotency, what gets rejected afterward, and what still isn't cancelled.
+---
+
+`sdk.destroy()` releases everything the SDK owns and puts the instance into a terminal, `destroyed` state. It's the one method every long-running process (a server, a worker, a test suite tearing down between cases) should call before letting an SDK instance go out of scope.
+
+```ts
+await sdk.destroy()
+```
+
+## Calling destroy()
+
+`destroy()` is **idempotent** — call it as many times as you like; the second call onward is a no-op that returns the same promise and starts no new work. That makes it safe to call from more than one shutdown hook (a `SIGTERM` handler and a framework's own teardown, for example) without coordinating who calls it first.
+
+```ts
+await sdk.destroy()
+await sdk.destroy() // no-op, resolves immediately
+```
+
+## What destroy() does
+
+Three independent steps run, each wrapped so a failure in one never skips the others — every failure is logged and swallowed, `destroy()` itself never rejects:
+
+1. **Closes every active WebSocket log stream** opened through `sdk.logs.connectByCore()`/`connectByNode()`.
+2. **Clears every webhook listener** registered with `sdk.webhook.on()`/`once()`.
+3. **Clears the stored access token.** This drops the reference only — JavaScript strings can't be reliably zeroed in memory, so this isn't a security wipe, just a "the token is no longer reachable through this instance" guarantee.
+
+## What rejects after destroy
+
+From the moment `destroy()` is called, these reject with `SdkDestroyedError` (code `SDK_DESTROYED`) instead of doing anything:
+
+| Call | Behavior after `destroy()` |
+|------|------|
+| `sdk.authorize()` | Throws synchronously |
+| `sdk.getAuthToken()` | Rejects |
+| `sdk.logs.connectByCore()` / `connectByNode()` | Rejects |
+| `sdk.webhook.parseWebhook()` | Rejects |
+| `sdk.webhook.handleWebhook()` | Rejects |
+| `sdk.webhook.dispatch()` | Rejects |
+
+```ts
+import { isSdkDestroyedError } from 'marzban-sdk'
+
+await sdk.destroy()
+
+try {
+  await sdk.authorize()
+} catch (err) {
+  if (isSdkDestroyedError(err)) {
+    // err.details.operation === 'authorize'
+  }
+}
+```
+
+## What still works after destroy
+
+`sdk.webhook.on()`, `once()`, and `off()` are **not** guarded — subscribing or, more importantly, unsubscribing after shutdown must stay safe, since a caller tearing down its own listeners shouldn't need to check whether the SDK died first.
+
+## What isn't covered
+
+- **Direct API calls** (`sdk.user.getUsers()`, `sdk.node.getNodes()`, …) are not rejected by `destroy()` itself. The access token is cleared, so such a call fails with the panel's own `401` once it reaches the network, and the SDK's automatic re-authentication is what actually rejects — with `SdkDestroyedError`, not a fresh login attempt.
+- **A request already in flight when `destroy()` is called is not cancelled.** It runs to completion (success, error response, or timeout) on its own.
+- **`httpAgent`/`httpsAgent`** passed in [config](/docs/configuration/config-options) are never touched. The SDK doesn't create that agent, so it doesn't own its lifecycle either — if you supplied one, you're responsible for calling its own `.destroy()`.
+
+## Graceful shutdown order
+
+If you're handling incoming webhooks on an HTTP server, close the server *before* calling `sdk.destroy()` — not after:
+
+```ts
+server.close(async () => {
+  await sdk.destroy()
+})
+```
+
+Calling `destroy()` first can make an in-flight webhook request hit `sdk.webhook.handleWebhook()` after it's already rejecting, returning a `500` to the panel and triggering an unnecessary retry.
+
+## Multiple SDK instances
+
+Each `MarzbanSDK` instance has its own `Lifecycle` state — destroying one instance never affects another, even against the same panel. See [HTTP & Retry](/docs/advanced/http-retry#multiple-sdk-instances) for the same guarantee applied to tokens and retry state.

--- a/apps/docs/content/docs/advanced/meta.json
+++ b/apps/docs/content/docs/advanced/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Advanced",
   "icon": "ShieldCheck",
-  "pages": ["error-handling", "validation", "http-retry"]
+  "pages": ["error-handling", "validation", "http-retry", "lifecycle"]
 }

--- a/apps/docs/src/components/docs/type-glossary.ts
+++ b/apps/docs/src/components/docs/type-glossary.ts
@@ -240,6 +240,10 @@ export const typeGlossary: Record<string, TypeInfo> = {
       'Signature verification was called in a browser context, which is unsupported (code WEBHOOK_ENVIRONMENT_ERROR).',
     href: '/docs/advanced/error-handling#error-codes-reference',
   },
+  SdkDestroyedError: {
+    description: 'Thrown by a guarded operation called after sdk.destroy() (code SDK_DESTROYED).',
+    href: '/docs/advanced/lifecycle#what-rejects-after-destroy',
+  },
 
   // ── Loose / dynamic values ─────────────────────────────────────────────
   ProxySettings: {

--- a/docs/adr/0015-sdk-destroy-terminal-lifecycle.md
+++ b/docs/adr/0015-sdk-destroy-terminal-lifecycle.md
@@ -1,0 +1,96 @@
+# ADR-0015: `MarzbanSDK.destroy()` is a terminal lifecycle transition
+
+Status: Accepted
+Date: 2026-09-03
+
+## Context
+
+`MarzbanSDK.destroy()` only closed active WebSocket log streams. Nothing
+defined what happens to the rest of the SDK's owned state when the instance
+stays referenced after shutdown — common in long-lived services, tests, hot
+reload, and graceful process termination
+([issue #84](https://github.com/Ilmar7786/marzban-sdk/issues/84)):
+
+- A pending 403 re-authentication/reconnect in `LogsStream` could still open
+  a new WebSocket connection after `destroy()` had already resolved.
+- `WebhookManager` kept every subscribed listener alive after `destroy()`,
+  with no operation to clear them.
+- The stored access token's fate after `destroy()` was undefined.
+- Whether any public operation (`authorize()`, `logs.connect*()`, webhook
+  processing) should still work after `destroy()` was undefined.
+
+`destroy()` also wasn't idempotent, and a throw from its one cleanup step
+had no defined interaction with other steps once more were added.
+
+## Decision
+
+`destroy()` is a terminal state transition, not just a cleanup routine —
+modeled on undici's `Client`, where every operation past `destroyed` rejects
+with a typed error (`ClientDestroyedError`) rather than silently continuing
+or reconnecting (the latter is what Prisma's `$disconnect()` does, and it's
+a [documented source of surprise](https://github.com/prisma/prisma/issues/12134)).
+
+- A single `Lifecycle` object (`core/lifecycle.ts`) is shared by
+  `MarzbanSDK` and every subsystem it owns (`AuthManager`, `LogsStream`,
+  `WebhookManager`) instead of each holding its own flag. `destroy()` calls
+  `markDestroyed()` on it before running any cleanup step, so a pending
+  operation observes the destroyed state at its next checkpoint.
+- `destroy()` is idempotent: a second call returns the same promise and
+  starts no new work.
+- From that point, `authorize()`, `getAuthToken()`, `logs.connect*()`, and
+  `webhook.parseWebhook()`/`handleWebhook()`/`dispatch()` reject with the new
+  `SdkDestroyedError`. `webhook.on()`/`once()`/`off()` keep working —
+  unsubscribing after shutdown must stay safe.
+- `WebhookManager` gains a `close()` that clears every listener.
+- `AuthManager` gains a `close()` that clears the stored access token
+  reference. No claim of memory zeroization is made — JavaScript strings are
+  immutable and can't be reliably scrubbed; this only drops the reference so
+  a live JWT doesn't sit reachable on a "destroyed" object. Stored
+  username/password are left alone: they belong to the caller's
+  `ValidatedConfig`, not to `AuthManager`, and re-authentication is rejected
+  by the guard above regardless.
+- The three cleanup steps (WebSocket streams, webhook listeners, auth state)
+  run independently — one throwing doesn't skip the others — matching the
+  cleanup-resilience `destroy()` already had for its one step.
+- Direct API calls (`sdk.user.*`, `sdk.node.*`, …) are deliberately **not**
+  guarded at the HTTP transport. The token being cleared makes such a call
+  fail with the panel's own 401, and the subsequent re-authentication attempt
+  is rejected by the `AuthManager` guard above. Guarding the transport itself
+  (`configureHttpClient`, `axios-retry`'s `retryCondition`, the 401 response
+  interceptor) was considered and rejected for this change: it would replace
+  `HttpError` with `SdkDestroyedError` for a request that was legally in
+  flight when `destroy()` was called, breaking `isHttpError()` checks on
+  existing consumer code, for a scenario (a stray call slightly after
+  shutdown) the simpler guard already makes safe in one hop. One HTTP
+  request can reach the network after `destroy()` in this scenario; an
+  already-in-flight request is not cancelled either way.
+- `LogsStream`'s reconnect race gets two checks, not one, because they guard
+  different call paths with different desired behavior: `connect()` itself
+  asserts active on entry, so a direct top-level `connectByCore()`/
+  `connectByNode()` call after `destroy()` rejects with `SdkDestroyedError`.
+  `LogsStreamRetryHandler.handleError()` separately checks
+  `lifecycle.destroyed` right after `await authService.retryAuth()` and,
+  if destroyed, returns quietly — no `emitError`, no reconnect — because the
+  consumer's handlers are already disposed of and forwarding the original
+  socket error there would be misleading.
+
+## Consequences
+
+- Calling any guarded operation after `destroy()` now throws/rejects instead
+  of silently succeeding or (for WS) silently reconnecting — a behavior
+  change for any consumer relying on post-destroy calls succeeding.
+  `BREAKING CHANGE`, shipped as part of `sdk-v4.0.0` (bundled with the
+  WS-specific reconnect rework in #88/#89/#90, which needed a major anyway).
+- `packages/mcp`'s only `destroy()` call
+  ([`packages/mcp/src/index.ts`](../../packages/mcp/src/index.ts)) is
+  immediately followed by `process.exit(0)`, so it's unaffected.
+- Full per-request cancellation (`AbortController`) and a graceful `close()`
+  that waits for in-flight work before tearing down remain out of scope —
+  `destroy()` stays the one abrupt terminal operation, matching undici's
+  `destroy()` half of its `close()`/`destroy()` pair without yet building the
+  `close()` half.
+- This ADR does not cover the WS module's reconnect state machine, phase-based
+  failure classification, or the per-stream `close()` handle race described
+  in issue #84's follow-up comment — that is
+  [issue #88](https://github.com/Ilmar7786/marzban-sdk/issues/88)'s scope,
+  which reuses the `Lifecycle` object introduced here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ What this enables, what it costs.
 | [0012](./0012-gate-dev-with-ci.md)                                   | Gate `dev`, not just `main`, with CI and branch protection          |
 | [0013](./0013-confirm-auto-trusts-a-call-not-a-tool.md)              | `confirm: 'auto'` trusts a call, not a tool                         |
 | [0014](./0014-git-cliff-unreleased-not-latest.md)                    | git-cliff uses `--unreleased`, tags pin to the commit CI ran on     |
+| [0015](./0015-sdk-destroy-terminal-lifecycle.md)                     | `MarzbanSDK.destroy()` is a terminal lifecycle transition           |

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -16,15 +16,15 @@ its own on top of HTTP.
 
 ## Directory map
 
-| Directory      | Role                                                                                                                        |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `src/index.ts` | The only public entry point.                                                                                                |
-| `src/core/`    | Hand-written infrastructure: `MarzbanSDK.ts` (the facade) plus `auth/`, `http/`, `errors/`, `logger/`, `webhook/`, `ws/`.   |
-| `src/config/`  | Zod config schema, defaults, validation.                                                                                    |
-| `src/common/`  | Runtime-agnostic utilities with no domain knowledge (redaction, byte/buffer helpers, event emitter, environment detection). |
-| `src/gen/`     | Fully generated from OpenAPI via kubb — `api/`, `models/`, `schemas/`. Committed to git, never hand-edited.                 |
-| `src/helpers/` | Convenience utilities for SDK consumers (bytes, datetime, pagination) — not used by `core/`.                                |
-| `src/testing/` | Test-only fixtures — see below.                                                                                             |
+| Directory      | Role                                                                                                                                                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/index.ts` | The only public entry point.                                                                                                                                          |
+| `src/core/`    | Hand-written infrastructure: `MarzbanSDK.ts` (the facade), `lifecycle.ts` (shared destroy-state flag) plus `auth/`, `http/`, `errors/`, `logger/`, `webhook/`, `ws/`. |
+| `src/config/`  | Zod config schema, defaults, validation.                                                                                                                              |
+| `src/common/`  | Runtime-agnostic utilities with no domain knowledge (redaction, byte/buffer helpers, event emitter, environment detection).                                           |
+| `src/gen/`     | Fully generated from OpenAPI via kubb — `api/`, `models/`, `schemas/`. Committed to git, never hand-edited.                                                           |
+| `src/helpers/` | Convenience utilities for SDK consumers (bytes, datetime, pagination) — not used by `core/`.                                                                          |
+| `src/testing/` | Test-only fixtures — see below.                                                                                                                                       |
 
 Dependency direction is one-way and acyclic: `index.ts → core/MarzbanSDK.ts →
 {config, core/*, gen/api}`. `common/` sits below everything and depends on
@@ -120,9 +120,26 @@ production.
 
 `SdkError<T>` is the base; `ERROR_CODES` is a fixed const map (`CONFIG_INVALID`,
 `NETWORK_HTTP_ERROR`, `AUTH_FAILED`, …). Categories (`HttpError`, `AuthError`,
-`ConfigurationError`, three `Webhook*Error` variants) extend it. Type guards
-(`isHttpError`, `isAuthError`, …) are the supported way to narrow — don't
-match on `error.code` strings or `instanceof` on internals.
+`ConfigurationError`, `SdkDestroyedError`, three `Webhook*Error` variants)
+extend it. Type guards (`isHttpError`, `isAuthError`, `isSdkDestroyedError`, …)
+are the supported way to narrow — don't match on `error.code` strings or
+`instanceof` on internals.
+
+## Lifecycle
+
+`core/lifecycle.ts`'s `Lifecycle` is one shared destroy-state flag, held by
+`MarzbanSDK` and passed into every subsystem it constructs (`AuthManager`,
+`LogsStream`, `WebhookManager`) instead of each keeping its own. It is
+internal — not exported from `src/index.ts` — since consumers interact with
+it only through `MarzbanSDK.destroy()` and the `SdkDestroyedError` it causes
+elsewhere to be thrown. `destroy()` calls `Lifecycle.markDestroyed()` before
+running its cleanup steps, and a subsystem calls `assertActive()` at points
+where continuing after shutdown would do the wrong thing — typically right
+after an `await`, since that's where a pending operation could otherwise
+resurrect work post-shutdown (a WebSocket 403 reconnect finishing after
+`destroy()` already resolved is the motivating case). See
+[ADR-0015](../../docs/adr/0015-sdk-destroy-terminal-lifecycle.md) for the
+full contract and why each subsystem's guard sits where it does.
 
 ## Extension points
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -65,6 +65,7 @@ const close = await sdk.logs.connectByCore({
 - 🎯 **Classified errors** — `AuthError`, `HttpError`, `ConfigurationError` and webhook errors all extend `SdkError` with a machine-readable code and type-guard helpers.
 - 📡 **Real-time logs & webhooks** — WebSocket log streams from the core and nodes, plus HMAC-verified inbound webhooks with typed event subscriptions.
 - 🔐 **Custom CA support** — pass a Node `httpsAgent` to trust a self-hosted panel's self-signed certificate, without disabling TLS verification.
+- 🧹 **Explicit shutdown** — `await sdk.destroy()` is idempotent and terminal: it closes WebSocket streams, clears webhook listeners and the stored token, and every guarded operation on that instance rejects with `SdkDestroyedError` from then on.
 
 ## Documentation
 
@@ -76,6 +77,7 @@ Full guides, configuration reference and the complete typed API live at
 - [Error handling](https://ilmar7786.github.io/marzban-sdk/docs/advanced/error-handling) & [validation](https://ilmar7786.github.io/marzban-sdk/docs/advanced/validation)
 - [Webhooks](https://ilmar7786.github.io/marzban-sdk/docs/webhooks/event-types) & [WebSocket logs](https://ilmar7786.github.io/marzban-sdk/docs/realtime/websocket-logs)
 - [Utilities](https://ilmar7786.github.io/marzban-sdk/docs/utilities/data-sizes)
+- [Lifecycle & shutdown](https://ilmar7786.github.io/marzban-sdk/docs/advanced/lifecycle)
 
 ## Contributing
 

--- a/packages/sdk/src/core/MarzbanSDK.test.ts
+++ b/packages/sdk/src/core/MarzbanSDK.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AnyType } from '@/common'
 
-import { HttpError } from './errors'
+import { HttpError, isSdkDestroyedError } from './errors'
+import { Lifecycle } from './lifecycle'
 import { LoggerConfig } from './logger'
 
 // ─── Shared mock references ───────────────────────────────────────────────────
@@ -33,9 +34,10 @@ class MockAuthManager {
   authenticate = vi.fn().mockResolvedValue(undefined)
   waitForCurrentAuth = vi.fn().mockResolvedValue(undefined)
   setPublicClient = vi.fn()
+  close = vi.fn()
 
-  constructor(storage: AnyType, logger: AnyType) {
-    mockAuthManagerCtor(storage, logger)
+  constructor(storage: AnyType, logger: AnyType, lifecycle: AnyType) {
+    mockAuthManagerCtor(storage, logger, lifecycle)
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     mockAuthInstance = this
   }
@@ -143,7 +145,8 @@ describe('MarzbanSDK', () => {
 
       expect(mockAuthManagerCtor).toHaveBeenCalledWith(
         { username: 'admin', password: 's3cr3t', accessToken: 'existing-token' },
-        expect.any(Object) // logger
+        expect.any(Object), // logger
+        expect.any(Lifecycle)
       )
     })
 
@@ -152,8 +155,21 @@ describe('MarzbanSDK', () => {
 
       expect(mockAuthManagerCtor).toHaveBeenCalledWith(
         expect.objectContaining({ accessToken: undefined }),
-        expect.anything()
+        expect.anything(),
+        expect.any(Lifecycle)
       )
+    })
+
+    it('passes the same Lifecycle instance shared with LogsStream and WebhookManager', () => {
+      new MarzbanSDK(BASE_CONFIG)
+
+      const [, , authLifecycle] = mockAuthManagerCtor.mock.calls[0]!
+      const { lifecycle: logsLifecycle } = mockLogsStreamCtor.mock.calls[0]![0]
+      const { lifecycle: webhookLifecycle } = mockWebhookManagerCtor.mock.calls[0]![0]
+
+      expect(authLifecycle).toBeInstanceOf(Lifecycle)
+      expect(logsLifecycle).toBe(authLifecycle)
+      expect(webhookLifecycle).toBe(authLifecycle)
     })
 
     it('registers the public HTTP client on the auth service', () => {
@@ -215,6 +231,7 @@ describe('MarzbanSDK', () => {
         authService: expect.any(MockAuthManager),
         logger: expect.any(Object),
         maxRetries: undefined, // config.retries is filled by validateConfig in production
+        lifecycle: expect.any(Lifecycle),
       })
     })
 
@@ -306,6 +323,37 @@ describe('MarzbanSDK', () => {
       expect(mockLogsStreamInstance.closeAllConnections).toHaveBeenCalledOnce()
     })
 
+    it('closes webhook listeners and clears the stored access token as independent steps', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+
+      await sdk.destroy()
+
+      expect(mockWebhookInstance.close).toHaveBeenCalledOnce()
+      expect(mockAuthInstance.close).toHaveBeenCalledOnce()
+    })
+
+    it('marks the shared lifecycle destroyed, which every subsystem observes', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+      const [, , lifecycle] = mockAuthManagerCtor.mock.calls[0]! as [unknown, unknown, Lifecycle]
+
+      await sdk.destroy()
+
+      expect(lifecycle.destroyed).toBe(true)
+    })
+
+    it('is idempotent: a second call returns the same promise and does not re-run cleanup', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+
+      const first = sdk.destroy()
+      const second = sdk.destroy()
+      await first
+
+      expect(second).toBe(first)
+      expect(mockLogsStreamInstance.closeAllConnections).toHaveBeenCalledOnce()
+      expect(mockWebhookInstance.close).toHaveBeenCalledOnce()
+      expect(mockAuthInstance.close).toHaveBeenCalledOnce()
+    })
+
     it('resolves successfully even when closeAllConnections throws', async () => {
       const sdk = new MarzbanSDK(BASE_CONFIG)
       mockLogsStreamInstance.closeAllConnections.mockImplementation(() => {
@@ -333,11 +381,77 @@ describe('MarzbanSDK', () => {
       })
 
       await expect(sdk.destroy()).resolves.toBeUndefined()
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Failed to close connections during destroy',
-        'string failure',
-        'MarzbanSDK'
-      )
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to clean up during destroy', 'string failure', 'MarzbanSDK')
+    })
+
+    it('runs webhook.close() and authService.close() even when closeAllConnections throws', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+      mockLogsStreamInstance.closeAllConnections.mockImplementation(() => {
+        throw new Error('logs step failed')
+      })
+
+      await sdk.destroy()
+
+      expect(mockWebhookInstance.close).toHaveBeenCalledOnce()
+      expect(mockAuthInstance.close).toHaveBeenCalledOnce()
+    })
+
+    it('runs closeAllConnections() and authService.close() even when webhook.close() throws', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+      mockWebhookInstance.close.mockImplementation(() => {
+        throw new Error('webhook step failed')
+      })
+
+      await sdk.destroy()
+
+      expect(mockLogsStreamInstance.closeAllConnections).toHaveBeenCalledOnce()
+      expect(mockAuthInstance.close).toHaveBeenCalledOnce()
+      expect(mockLogger.error).toHaveBeenCalledWith('webhook step failed', expect.anything(), 'MarzbanSDK')
+    })
+
+    it('runs closeAllConnections() and webhook.close() even when authService.close() throws', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+      mockAuthInstance.close.mockImplementation(() => {
+        throw new Error('auth step failed')
+      })
+
+      await sdk.destroy()
+
+      expect(mockLogsStreamInstance.closeAllConnections).toHaveBeenCalledOnce()
+      expect(mockWebhookInstance.close).toHaveBeenCalledOnce()
+      expect(mockLogger.error).toHaveBeenCalledWith('auth step failed', expect.anything(), 'MarzbanSDK')
+    })
+
+    it('rejects authorize() with SdkDestroyedError once destroyed', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+      await sdk.destroy()
+
+      let thrown: unknown
+      try {
+        sdk.authorize()
+      } catch (err) {
+        thrown = err
+      }
+
+      expect(isSdkDestroyedError(thrown)).toBe(true)
+    })
+
+    it('rejects getAuthToken() with SdkDestroyedError once destroyed', async () => {
+      const sdk = new MarzbanSDK(BASE_CONFIG)
+      await sdk.destroy()
+
+      await expect(sdk.getAuthToken()).rejects.toEqual(expect.objectContaining({ code: 'SDK_DESTROYED' }))
+    })
+
+    it('never touches caller-supplied httpAgent/httpsAgent — the SDK does not own their lifecycle', async () => {
+      const httpAgent = { destroy: vi.fn() }
+      const httpsAgent = { destroy: vi.fn() }
+      const sdk = new MarzbanSDK({ ...BASE_CONFIG, httpAgent, httpsAgent })
+
+      await sdk.destroy()
+
+      expect(httpAgent.destroy).not.toHaveBeenCalled()
+      expect(httpsAgent.destroy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/sdk/src/core/MarzbanSDK.ts
+++ b/packages/sdk/src/core/MarzbanSDK.ts
@@ -4,6 +4,7 @@ import { adminApi, coreApi, nodeApi, subscriptionApi, systemApi, userApi, userTe
 import { AuthManager } from './auth'
 import { SdkError } from './errors'
 import { configureHttpClient } from './http'
+import { Lifecycle } from './lifecycle'
 import { createLogger, Logger } from './logger'
 import { TolerantUserApi } from './quirks/tolerant-user-api'
 import { WebhookManager } from './webhook'
@@ -18,6 +19,8 @@ export class MarzbanSDK {
   private readonly _config: ValidatedConfig
   private readonly _authService: AuthManager
   private readonly _logger: Logger
+  private readonly _lifecycle: Lifecycle
+  private _destroyPromise: Promise<void> | null = null
 
   /**
    * Administrative API endpoints.
@@ -127,13 +130,14 @@ export class MarzbanSDK {
   constructor(config: Config) {
     this._config = validateConfig(config)
     this._logger = createLogger(this._config.logger)
+    this._lifecycle = new Lifecycle()
 
     const storageAuth: AuthManager['storage'] = {
       username: this._config.username,
       password: this._config.password,
       accessToken: this._config.token,
     }
-    this._authService = new AuthManager(storageAuth, this._logger)
+    this._authService = new AuthManager(storageAuth, this._logger, this._lifecycle)
 
     const http = configureHttpClient(this._config.baseUrl, this._authService, this._config, this._logger)
     this._authService.setPublicClient(http.publicClient)
@@ -151,8 +155,9 @@ export class MarzbanSDK {
       logger: this._logger,
       maxRetries: this._config.retries,
       httpsAgent: this._config.httpsAgent,
+      lifecycle: this._lifecycle,
     })
-    this.webhook = new WebhookManager({ ...this._config.webhook, logger: this._logger })
+    this.webhook = new WebhookManager({ ...this._config.webhook, logger: this._logger, lifecycle: this._lifecycle })
 
     this._logger.debug('MarzbanSDK instance created', 'MarzbanSDK')
   }
@@ -163,12 +168,14 @@ export class MarzbanSDK {
    * Waits for any in-progress authentication, then returns the JWT token in use (or empty string if none).
    *
    * @returns {Promise<string>} The current JWT token.
+   * @throws {SdkDestroyedError} If the SDK has been destroyed.
    *
    * @example
    * const token = await sdk.getAuthToken();
    * console.log(`Token: ${token}`);
    */
   async getAuthToken(): Promise<string> {
+    this._lifecycle.assertActive('getAuthToken')
     await this._authService.waitForCurrentAuth()
     return this._authService.accessToken
   }
@@ -179,6 +186,7 @@ export class MarzbanSDK {
    * If a login is already in progress, returns the existing promise (deduplicates concurrent calls).
    *
    * @returns {Promise<void>} Resolves on successful authentication; rejects with {@link AuthError} on failure.
+   * @throws {SdkDestroyedError} If the SDK has been destroyed.
    *
    * @example
    * try {
@@ -191,16 +199,31 @@ export class MarzbanSDK {
    * }
    */
   authorize(): Promise<void> {
+    this._lifecycle.assertActive('authorize')
     // Concurrent-call de-duplication is handled inside AuthManager.authenticate,
     // which returns the in-flight promise when a login is already running.
     return this._authService.authenticate(this._config.username, this._config.password)
   }
 
   /**
-   * Releases resources held by the SDK.
+   * Releases resources held by the SDK and enters a terminal `destroyed`
+   * state. Idempotent — calling it again after the first call returns the
+   * same promise and starts no new work.
    *
-   * Closes all active WebSocket log streams. Safe to call multiple times;
-   * any error while closing connections is logged and swallowed.
+   * From the point `destroy()` is called, every other public operation on
+   * this instance — `authorize()`, `getAuthToken()`, `logs.connect*()`, and
+   * `webhook.parseWebhook()`/`handleWebhook()`/`dispatch()` — rejects with
+   * `SdkDestroyedError`. `webhook.on()`/`once()`/`off()` keep working, so
+   * unsubscribing after shutdown stays safe. Direct API calls (`sdk.user.*`,
+   * `sdk.node.*`, …) are not rejected by this method: the stored access token
+   * is cleared, so such a call fails with the panel's own 401 instead once
+   * re-authentication is attempted and rejected as above. An HTTP request
+   * already in flight when `destroy()` is called is not cancelled.
+   *
+   * Runs three independent cleanup steps — closing active WebSocket log
+   * streams, clearing webhook listeners, and clearing the stored access
+   * token — each wrapped so a throw from one never skips the others; every
+   * failure is logged and swallowed.
    *
    * Does not touch `httpAgent`/`httpsAgent` from {@link Config} — the SDK
    * never creates that agent, so it doesn't own or destroy it either;
@@ -208,17 +231,37 @@ export class MarzbanSDK {
    *
    * @returns {Promise<void>} Resolves once cleanup has completed.
    */
-  async destroy(): Promise<void> {
+  destroy(): Promise<void> {
+    if (!this._destroyPromise) {
+      this._destroyPromise = this.destroyInternal()
+    }
+    return this._destroyPromise
+  }
+
+  private async destroyInternal(): Promise<void> {
     this._logger.info('Destroying SDK and closing active connections', 'MarzbanSDK')
+
+    // Marked first, before any cleanup step runs, so a 403 reconnect or any
+    // other pending operation observes the destroyed state at its next
+    // checkpoint instead of racing shutdown to completion.
+    this._lifecycle.markDestroyed()
+
+    this.runCleanupStep(() => this.logs.closeAllConnections())
+    this.runCleanupStep(() => this.webhook.close())
+    this.runCleanupStep(() => this._authService.close())
+  }
+
+  /** Runs one independent destroy step, logging rather than throwing if it fails — so the others still run. */
+  private runCleanupStep(step: () => void): void {
     try {
-      this.logs.closeAllConnections()
+      step()
     } catch (err) {
       if (err instanceof SdkError) {
         this._logger.error(err.message, err.stack, err.code)
       } else if (err instanceof Error) {
         this._logger.error(err.message, err.stack, 'MarzbanSDK')
       } else {
-        this._logger.error('Failed to close connections during destroy', err, 'MarzbanSDK')
+        this._logger.error('Failed to clean up during destroy', err, 'MarzbanSDK')
       }
     }
   }

--- a/packages/sdk/src/core/auth/auth.manager.test.ts
+++ b/packages/sdk/src/core/auth/auth.manager.test.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-empty */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AuthError, AuthTokenError } from '@/core/errors'
+import { AuthError, AuthTokenError, isSdkDestroyedError } from '@/core/errors'
 import { Logger } from '@/core/logger'
 
+import { Lifecycle } from '../lifecycle'
 import { AuthManager } from './auth.manager'
 import { Storage } from './auth.types'
 
@@ -297,6 +298,55 @@ describe('AuthManager', () => {
       makeAdminToken({ access_token: 'tok' })
       await manager.retryAuth()
       expect(storage.accessToken).toBe('tok')
+    })
+  })
+
+  // ─── close ────────────────────────────────────────────────────────────────
+
+  describe('close', () => {
+    it('clears the stored access token', () => {
+      storage.accessToken = 'live-token'
+      manager.close()
+      expect(storage.accessToken).toBeUndefined()
+    })
+
+    it('logs debug when the token is cleared', () => {
+      manager.close()
+      expect(logger.debug).toHaveBeenCalledWith('Access token cleared', 'AuthManager')
+    })
+
+    it('does not touch stored username/password', () => {
+      manager.close()
+      expect(storage.username).toBe('admin')
+      expect(storage.password).toBe('secret')
+    })
+  })
+
+  // ─── lifecycle guard ────────────────────────────────────────────────────────
+
+  describe('when the owning SDK is destroyed', () => {
+    it('authenticate() throws SdkDestroyedError instead of making a request', () => {
+      const lifecycle = new Lifecycle()
+      const destroyedManager = new AuthManager(storage, logger, lifecycle)
+      lifecycle.markDestroyed()
+
+      let thrown: unknown
+      try {
+        destroyedManager.authenticate('admin', 'secret')
+      } catch (err) {
+        thrown = err
+      }
+
+      expect(isSdkDestroyedError(thrown)).toBe(true)
+      expect(mockAdminApi).not.toHaveBeenCalled()
+    })
+
+    it('retryAuth() propagates the same SdkDestroyedError (it delegates to authenticate())', () => {
+      const lifecycle = new Lifecycle()
+      const destroyedManager = new AuthManager(storage, logger, lifecycle)
+      lifecycle.markDestroyed()
+
+      expect(() => destroyedManager.retryAuth()).toThrow(expect.objectContaining({ code: 'SDK_DESTROYED' }))
     })
   })
 })

--- a/packages/sdk/src/core/auth/auth.manager.ts
+++ b/packages/sdk/src/core/auth/auth.manager.ts
@@ -4,11 +4,13 @@ import { AuthError, AuthTokenError } from '@/core/errors'
 import { Logger } from '@/core/logger'
 import { adminApi } from '@/gen/api'
 
+import { Lifecycle } from '../lifecycle'
 import { Storage } from './auth.types'
 
 export class AuthManager {
   private readonly storage: Storage
   private readonly logger: Logger
+  private readonly lifecycle: Lifecycle
   /** When set, used for login (adminToken) instead of global client. */
   private httpClient!: Client
 
@@ -19,9 +21,10 @@ export class AuthManager {
     return this._authPromise
   }
 
-  constructor(storage: Storage, logger: Logger) {
+  constructor(storage: Storage, logger: Logger, lifecycle: Lifecycle = new Lifecycle()) {
     this.storage = storage
     this.logger = logger
+    this.lifecycle = lifecycle
     this.logger.debug('AuthManager initialized', 'AuthManager')
   }
 
@@ -31,7 +34,10 @@ export class AuthManager {
     return this
   }
 
+  /** @throws {SdkDestroyedError} If the owning SDK has been destroyed. */
   authenticate(username: string, password: string): Promise<void> {
+    this.lifecycle.assertActive('authenticate')
+
     if (this._authPromise) {
       this.logger.debug('Authentication already in progress, returning existing promise', 'AuthManager')
       return this._authPromise
@@ -111,5 +117,15 @@ export class AuthManager {
       this._authPromise = null
       this.logger.debug('Authentication process completed', 'AuthManager')
     }
+  }
+
+  /**
+   * Clears the stored access token reference. Does not touch the stored
+   * username/password — those belong to the caller's `ValidatedConfig`, and
+   * `authenticate()` is rejected once the owning SDK is destroyed anyway.
+   */
+  close(): void {
+    this.storage.accessToken = undefined
+    this.logger.debug('Access token cleared', 'AuthManager')
   }
 }

--- a/packages/sdk/src/core/errors/categories/index.ts
+++ b/packages/sdk/src/core/errors/categories/index.ts
@@ -1,5 +1,6 @@
 export * from './auth.error'
 export * from './configuration.error'
 export * from './http.error'
+export * from './lifecycle.error'
 export * from './webhook.error'
 export * from './ws.error'

--- a/packages/sdk/src/core/errors/categories/lifecycle.error.ts
+++ b/packages/sdk/src/core/errors/categories/lifecycle.error.ts
@@ -1,0 +1,9 @@
+import { ERROR_CODES } from '../codes'
+import { SdkError } from '../sdk.error'
+
+/** Thrown by any SDK operation attempted after `MarzbanSDK.destroy()` has been called. */
+export class SdkDestroyedError extends SdkError<{ operation: string }> {
+  constructor(operation: string) {
+    super(ERROR_CODES.SDK_DESTROYED, { operation })
+  }
+}

--- a/packages/sdk/src/core/errors/codes.ts
+++ b/packages/sdk/src/core/errors/codes.ts
@@ -6,6 +6,8 @@ export interface FormatCode {
 export const ERROR_CODES = {
   CONFIG_INVALID: { code: 'CONFIG_INVALID', message: 'Invalid SDK configuration' },
 
+  SDK_DESTROYED: { code: 'SDK_DESTROYED', message: 'The SDK instance has been destroyed' },
+
   NETWORK_HTTP_ERROR: { code: 'NETWORK_HTTP_ERROR', message: 'HTTP request failed' },
 
   AUTH_TOKEN_FAILED: { code: 'AUTH_TOKEN_FAILED', message: 'Failed to retrieve access token' },

--- a/packages/sdk/src/core/errors/errors.test.ts
+++ b/packages/sdk/src/core/errors/errors.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { AuthError, AuthTokenError } from './categories/auth.error'
 import { ConfigurationError } from './categories/configuration.error'
 import { HttpError } from './categories/http.error'
+import { SdkDestroyedError } from './categories/lifecycle.error'
 import { WebhookEnvironmentError, WebhookSignatureError, WebhookValidationError } from './categories/webhook.error'
 import { ERROR_CODES, ErrorCode } from './codes'
 import { isAuthError, isAuthTokenError } from './guards/auth.guard'
 import { isConfigurationError } from './guards/configuration.guard'
 import { isHttpError } from './guards/http.guard'
+import { isSdkDestroyedError } from './guards/lifecycle.guard'
 import { isSdkError } from './guards/sdk.guard'
 import { isWebhookEnvironmentError, isWebhookSignatureError, isWebhookValidationError } from './guards/webhook.guard'
 import { SdkError } from './sdk.error'
@@ -153,6 +155,20 @@ describe('AuthTokenError', () => {
 
   it('sets name to AuthTokenError', () => {
     expect(new AuthTokenError().name).toBe('AuthTokenError')
+  })
+})
+
+describe('SdkDestroyedError', () => {
+  it('has the correct code', () => {
+    expect(new SdkDestroyedError('authorize').code).toBe(ERROR_CODES.SDK_DESTROYED.code)
+  })
+
+  it('sets name to SdkDestroyedError', () => {
+    expect(new SdkDestroyedError('authorize').name).toBe('SdkDestroyedError')
+  })
+
+  it('carries the failed operation in details', () => {
+    expect(new SdkDestroyedError('logs.connectByCore').details).toEqual({ operation: 'logs.connectByCore' })
   })
 })
 
@@ -372,5 +388,19 @@ describe('isWebhookEnvironmentError', () => {
 
   it('returns false for null', () => {
     expect(isWebhookEnvironmentError(null)).toBe(false)
+  })
+})
+
+describe('isSdkDestroyedError', () => {
+  it('returns true for SdkDestroyedError', () => {
+    expect(isSdkDestroyedError(new SdkDestroyedError('authorize'))).toBe(true)
+  })
+
+  it('returns false for a plain AuthError', () => {
+    expect(isSdkDestroyedError(new AuthError())).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isSdkDestroyedError(null)).toBe(false)
   })
 })

--- a/packages/sdk/src/core/errors/guards/index.ts
+++ b/packages/sdk/src/core/errors/guards/index.ts
@@ -1,6 +1,7 @@
 export * from './auth.guard'
 export * from './configuration.guard'
 export * from './http.guard'
+export * from './lifecycle.guard'
 export * from './sdk.guard'
 export * from './webhook.guard'
 export * from './ws.guard'

--- a/packages/sdk/src/core/errors/guards/lifecycle.guard.ts
+++ b/packages/sdk/src/core/errors/guards/lifecycle.guard.ts
@@ -1,0 +1,5 @@
+import { SdkDestroyedError } from '../categories'
+
+export const isSdkDestroyedError = (error: unknown): error is SdkDestroyedError => {
+  return error instanceof SdkDestroyedError
+}

--- a/packages/sdk/src/core/lifecycle.test.ts
+++ b/packages/sdk/src/core/lifecycle.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSdkDestroyedError } from './errors'
+import { Lifecycle } from './lifecycle'
+
+describe('Lifecycle', () => {
+  it('starts active (not destroyed)', () => {
+    const lifecycle = new Lifecycle()
+    expect(lifecycle.destroyed).toBe(false)
+  })
+
+  it('assertActive() does not throw while active', () => {
+    const lifecycle = new Lifecycle()
+    expect(() => lifecycle.assertActive('op')).not.toThrow()
+  })
+
+  it('markDestroyed() flips destroyed to true', () => {
+    const lifecycle = new Lifecycle()
+    lifecycle.markDestroyed()
+    expect(lifecycle.destroyed).toBe(true)
+  })
+
+  it('markDestroyed() is idempotent', () => {
+    const lifecycle = new Lifecycle()
+    lifecycle.markDestroyed()
+    lifecycle.markDestroyed()
+    expect(lifecycle.destroyed).toBe(true)
+  })
+
+  it('assertActive() throws SdkDestroyedError once destroyed', () => {
+    const lifecycle = new Lifecycle()
+    lifecycle.markDestroyed()
+
+    let thrown: unknown
+    try {
+      lifecycle.assertActive('someOperation')
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(isSdkDestroyedError(thrown)).toBe(true)
+  })
+
+  it('SdkDestroyedError carries the failed operation name in details', () => {
+    const lifecycle = new Lifecycle()
+    lifecycle.markDestroyed()
+
+    let thrown: unknown
+    try {
+      lifecycle.assertActive('logs.connectByCore')
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(isSdkDestroyedError(thrown) && thrown.details).toEqual({ operation: 'logs.connectByCore' })
+  })
+})

--- a/packages/sdk/src/core/lifecycle.ts
+++ b/packages/sdk/src/core/lifecycle.ts
@@ -1,0 +1,27 @@
+import { SdkDestroyedError } from './errors'
+
+/**
+ * Shared terminal-state flag for one `MarzbanSDK` instance. `MarzbanSDK.destroy()`
+ * calls {@link markDestroyed} once; every subsystem it owns (`AuthManager`,
+ * `LogsStream`, `WebhookManager`) holds the same instance instead of a private
+ * flag, and calls {@link assertActive} — typically right after an `await`,
+ * where a pending operation could otherwise resurrect work post-shutdown.
+ */
+export class Lifecycle {
+  private _destroyed = false
+
+  get destroyed(): boolean {
+    return this._destroyed
+  }
+
+  markDestroyed(): void {
+    this._destroyed = true
+  }
+
+  /** @throws {SdkDestroyedError} If `markDestroyed()` has already been called. */
+  assertActive(operation: string): void {
+    if (this._destroyed) {
+      throw new SdkDestroyedError(operation)
+    }
+  }
+}

--- a/packages/sdk/src/core/webhook/webhook.manager.test.ts
+++ b/packages/sdk/src/core/webhook/webhook.manager.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { WebhookSignatureError, WebhookValidationError } from '@/core/errors'
+import { isSdkDestroyedError, WebhookSignatureError, WebhookValidationError } from '@/core/errors'
 import { Logger } from '@/core/logger'
 
+import { Lifecycle } from '../lifecycle'
 import { WebhookManager } from './webhook.manager'
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
@@ -344,6 +345,67 @@ describe('WebhookManager', () => {
       await manager.dispatch('user_updated' as never, payload as never)
       expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Dispatching'), 'WebhookManager')
       expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Event dispatched'), 'WebhookManager')
+    })
+  })
+
+  // ─── close ────────────────────────────────────────────────────────────────
+
+  describe('close', () => {
+    it('removes every registered listener', async () => {
+      const payload = makePayload()
+      mockValidate.mockReturnValue([payload] as never)
+      const wildcardListener = vi.fn()
+      const batchListener = vi.fn()
+      manager.on('*', wildcardListener)
+      manager.on('batch', batchListener)
+
+      manager.close()
+      const result = await manager.handleWebhook([payload])
+
+      expect(result).toBe(false)
+      expect(wildcardListener).not.toHaveBeenCalled()
+      expect(batchListener).not.toHaveBeenCalled()
+    })
+
+    it('logs debug when closed', () => {
+      manager.close()
+      expect(logger.debug).toHaveBeenCalledWith('WebhookManager closed, all listeners removed', 'WebhookManager')
+    })
+  })
+
+  // ─── lifecycle guard ────────────────────────────────────────────────────────
+
+  describe('when the owning SDK is destroyed', () => {
+    let lifecycle: Lifecycle
+    let destroyedManager: WebhookManager
+
+    beforeEach(() => {
+      lifecycle = new Lifecycle()
+      destroyedManager = new WebhookManager({ logger, lifecycle })
+      lifecycle.markDestroyed()
+    })
+
+    it('parseWebhook() rejects with SdkDestroyedError', async () => {
+      await expect(destroyedManager.parseWebhook([])).rejects.toSatisfy(isSdkDestroyedError)
+    })
+
+    it('handleWebhook() rejects with SdkDestroyedError, not WebhookValidationError', async () => {
+      await expect(destroyedManager.handleWebhook([])).rejects.toSatisfy(isSdkDestroyedError)
+    })
+
+    it('dispatch() rejects with SdkDestroyedError', async () => {
+      await expect(destroyedManager.dispatch('user_created' as never, {} as never)).rejects.toSatisfy(
+        isSdkDestroyedError
+      )
+    })
+
+    it('off() still works — unsubscribing after shutdown stays safe', () => {
+      const listener = vi.fn()
+      expect(() => destroyedManager.off('*', listener)).not.toThrow()
+    })
+
+    it('on() still works — a new subscription after shutdown does not throw', () => {
+      expect(() => destroyedManager.on('*', vi.fn())).not.toThrow()
     })
   })
 })

--- a/packages/sdk/src/core/webhook/webhook.manager.ts
+++ b/packages/sdk/src/core/webhook/webhook.manager.ts
@@ -2,6 +2,7 @@ import { SafeEventEmitter, toBytes } from '@/common'
 import { SdkError, WebhookSignatureError, WebhookValidationError } from '@/core/errors'
 import { Logger } from '@/core/logger'
 
+import { Lifecycle } from '../lifecycle'
 import { WebhookType } from './webhook.schema'
 import { validateWebhookPayload, verifyWebhookSignature } from './webhook.utils'
 
@@ -45,6 +46,9 @@ export interface WebhookManagerOptions {
    * Logger instance used for internal webhook logging.
    */
   logger: Logger
+
+  /** Shared SDK-instance terminal-state flag. Defaults to a fresh, always-active one when omitted. */
+  lifecycle?: Lifecycle
 }
 
 /**
@@ -77,15 +81,17 @@ export class WebhookManager {
   private readonly _secret?: string
   private readonly _emitter: SafeEventEmitter<WebhookEventMap>
   private readonly _logger: Logger
+  private readonly _lifecycle: Lifecycle
 
   /**
    * @param options Webhook manager options.
    * @param options.secret Optional webhook secret for verifying signatures.
    * @param options.logger Logger instance for logging events.
    */
-  constructor({ secret, logger }: WebhookManagerOptions) {
+  constructor({ secret, logger, lifecycle = new Lifecycle() }: WebhookManagerOptions) {
     this._secret = secret
     this._logger = logger
+    this._lifecycle = lifecycle
     this._emitter = new SafeEventEmitter<WebhookEventMap>()
 
     this._logger.debug('WebhookManager initialized', 'WebhookManager')
@@ -132,8 +138,10 @@ export class WebhookManager {
    * @param rawBody Incoming webhook raw body (string|Uint8Array|ArrayBuffer) OR already-parsed object.
    * @param signature Optional webhook signature to verify (hex string)
    * @returns Array of validated webhook payloads
+   * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    */
   async parseWebhook(rawBody: unknown, signature?: string): Promise<WebhookType[]> {
+    this._lifecycle.assertActive('webhook.parseWebhook')
     this._logger.debug('Parsing incoming webhook payload', 'WebhookManager')
 
     // If secret is configured — require signature and raw body bytes.
@@ -200,8 +208,10 @@ export class WebhookManager {
    * @param rawBody Incoming webhook raw body (string|Uint8Array|ArrayBuffer) or already-parsed object
    * @param signature Optional signature for verification
    * @returns true if at least one event had listeners
+   * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    */
   async handleWebhook(rawBody: unknown, signature?: string): Promise<boolean> {
+    this._lifecycle.assertActive('webhook.handleWebhook')
     this._logger.debug('Handling incoming webhook', 'WebhookManager')
     let emitted = false
 
@@ -241,14 +251,25 @@ export class WebhookManager {
    * @param event Event name (specific action, '*', or 'batch')
    * @param payload Payload to emit
    * @returns true if event had listeners
+   * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    */
   async dispatch<E extends keyof Omit<WebhookEventMap, '*' | 'batch'>>(
     event: E,
     payload: WebhookEventMap[E]
   ): Promise<boolean> {
+    this._lifecycle.assertActive('webhook.dispatch')
     this._logger.debug(`Dispatching event: ${String(event)}`, 'WebhookManager')
     const result = await this._emitter.emitAsync(event, payload)
     this._logger.debug(`Event dispatched: ${String(event)}, result=${result}`, 'WebhookManager')
     return result
+  }
+
+  /**
+   * Removes every registered listener (specific-action, wildcard, and batch).
+   * Called by `MarzbanSDK.destroy()`; safe to call directly.
+   */
+  close(): void {
+    this._emitter.removeAllListeners()
+    this._logger.debug('WebhookManager closed, all listeners removed', 'WebhookManager')
   }
 }

--- a/packages/sdk/src/core/ws/logs-stream-retry.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream-retry.test.ts
@@ -4,6 +4,7 @@ import type { AnyType } from '@/common'
 import type { AuthManager } from '@/core/auth'
 import type { Logger } from '@/core/logger'
 
+import { Lifecycle } from '../lifecycle'
 import type { BaseWebSocketClient } from './client'
 import type { LogOptions } from './logs-stream'
 import { LogsStreamRetryHandler } from './logs-stream-retry'
@@ -16,6 +17,7 @@ const options: LogOptions = { onMessage: () => {} }
 function createHandler(
   overrides: {
     maxRetries?: number
+    lifecycle?: Lifecycle
     retryAuth?: () => Promise<void>
     reconnect?: (endpoint: string, options: LogOptions, retryCount: number) => Promise<HandleCloseConnection>
   } = {}
@@ -31,6 +33,7 @@ function createHandler(
     authService,
     logger,
     maxRetries: overrides.maxRetries ?? 3,
+    lifecycle: overrides.lifecycle,
     closeTracked,
     reconnect,
   })
@@ -171,6 +174,34 @@ describe('LogsStreamRetryHandler', () => {
     })
 
     expect(emitError).toHaveBeenCalledTimes(1)
+    expect(connection.close).toBe(originalClose)
+  })
+
+  it('abandons the reconnect quietly when the SDK is destroyed while retryAuth() is in flight', async () => {
+    const lifecycle = new Lifecycle()
+    const originalClose = vi.fn()
+    const { handler, reconnect } = createHandler({
+      lifecycle,
+      retryAuth: vi.fn().mockImplementation(async () => {
+        // Simulates MarzbanSDK.destroy() running concurrently with retryAuth().
+        lifecycle.markDestroyed()
+      }),
+    })
+    const emitError = vi.fn()
+    const connection: ConnectionHandle = { close: originalClose }
+
+    await handler.handleError({
+      wsClient,
+      endpoint,
+      options,
+      retryCount: 0,
+      event: { message: '403 Forbidden' } as AnyType,
+      emitError,
+      connection,
+    })
+
+    expect(reconnect).not.toHaveBeenCalled()
+    expect(emitError).not.toHaveBeenCalled()
     expect(connection.close).toBe(originalClose)
   })
 })

--- a/packages/sdk/src/core/ws/logs-stream-retry.ts
+++ b/packages/sdk/src/core/ws/logs-stream-retry.ts
@@ -1,6 +1,7 @@
 import { AuthManager } from '@/core/auth'
 import { Logger } from '@/core/logger'
 
+import { Lifecycle } from '../lifecycle'
 import { BaseWebSocketClient } from './client'
 import type { LogOptions } from './logs-stream'
 import type { ConnectionHandle, HandleCloseConnection } from './utils/connection-handle.types'
@@ -10,6 +11,8 @@ export interface LogsStreamRetryHandlerOptions {
   authService: AuthManager
   logger: Logger
   maxRetries: number
+  /** Shared SDK-instance terminal-state flag. Defaults to a fresh, always-active one when omitted. */
+  lifecycle?: Lifecycle
   /** Untracks and closes the failed socket, logging rather than throwing if `close()` itself fails. */
   closeTracked: (wsClient: BaseWebSocketClient, endpoint: string) => void
   /** Opens a brand new connection for the same endpoint/options, one retry attempt further in. */
@@ -27,6 +30,7 @@ export class LogsStreamRetryHandler {
   private readonly authService: AuthManager
   private readonly logger: Logger
   private readonly maxRetries: number
+  private readonly lifecycle: Lifecycle
   private readonly closeTracked: LogsStreamRetryHandlerOptions['closeTracked']
   private readonly reconnect: LogsStreamRetryHandlerOptions['reconnect']
 
@@ -34,6 +38,7 @@ export class LogsStreamRetryHandler {
     this.authService = options.authService
     this.logger = options.logger
     this.maxRetries = options.maxRetries
+    this.lifecycle = options.lifecycle ?? new Lifecycle()
     this.closeTracked = options.closeTracked
     this.reconnect = options.reconnect
   }
@@ -74,6 +79,15 @@ export class LogsStreamRetryHandler {
 
     try {
       await this.authService.retryAuth()
+
+      // The SDK may have been destroyed while retryAuth() was in flight — the
+      // consumer's handlers are already disposed of, so give up quietly
+      // instead of opening a socket nobody is going to close.
+      if (this.lifecycle.destroyed) {
+        this.logger.debug('SDK destroyed during 403 re-auth, abandoning reconnect', 'LogsStream')
+        return
+      }
+
       connection.close = await this.reconnect(endpoint, options, retryCount + 1)
     } catch {
       emitError(event)

--- a/packages/sdk/src/core/ws/logs-stream.server.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream.server.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AnyType } from '@/common'
-import { WsOptionsError } from '@/core/errors'
+import { isSdkDestroyedError, WsOptionsError } from '@/core/errors'
 import { createMarzbanSDK, type MarzbanSDK } from '@/core/MarzbanSDK'
 import type { MockPanel } from '@/testing'
 import { selectWsTransport, startMockPanel, WS_TRANSPORTS } from '@/testing'
@@ -89,6 +89,16 @@ describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName =
     await vi.waitFor(() => {
       sockets.forEach(socket => expect(socket.readyState).toBe(socket.CLOSED))
     })
+  })
+
+  it('connectByCore() rejects with SdkDestroyedError once destroy() has resolved (#84)', async () => {
+    const instance = await connectSdk()
+
+    await instance.destroy()
+
+    await expect(instance.logs.connectByCore({ onMessage: () => {} })).rejects.toSatisfy(isSdkDestroyedError)
+    // No new connection reached the panel for the rejected call above.
+    expect(panel.sockets.size).toBe(0)
   })
 
   it('a fresh login flows through to the next connection', async () => {

--- a/packages/sdk/src/core/ws/logs-stream.ts
+++ b/packages/sdk/src/core/ws/logs-stream.ts
@@ -3,6 +3,7 @@ import { DEFAULT_RETRIES } from '@/config'
 import { AuthManager } from '@/core/auth'
 import { Logger } from '@/core/logger'
 
+import { Lifecycle } from '../lifecycle'
 import { BaseWebSocketClient, WebSocketClient } from './client'
 import { LogsStreamRetryHandler } from './logs-stream-retry'
 import { configurationUrlWs } from './utils'
@@ -39,6 +40,8 @@ export interface LogsStreamOptions {
    * e.g. to trust a self-signed panel certificate. Ignored in the browser.
    */
   httpsAgent?: HttpAgentLike
+  /** Shared SDK-instance terminal-state flag. Defaults to a fresh, always-active one when omitted. */
+  lifecycle?: Lifecycle
 }
 
 /**
@@ -51,21 +54,31 @@ export class LogsStream {
   private logger: Logger
   private activeConnections: Set<BaseWebSocketClient> = new Set()
   private httpsAgent?: HttpAgentLike
+  private lifecycle: Lifecycle
   private retryHandler: LogsStreamRetryHandler
 
   /**
    * Creates an API instance for handling logs via WebSocket.
    * @param options Configuration for the log stream. See {@link LogsStreamOptions}.
    */
-  constructor({ basePath, authService, logger, maxRetries = DEFAULT_RETRIES, httpsAgent }: LogsStreamOptions) {
+  constructor({
+    basePath,
+    authService,
+    logger,
+    maxRetries = DEFAULT_RETRIES,
+    httpsAgent,
+    lifecycle = new Lifecycle(),
+  }: LogsStreamOptions) {
     this.basePath = basePath
     this.authService = authService
     this.logger = logger
     this.httpsAgent = httpsAgent
+    this.lifecycle = lifecycle
     this.retryHandler = new LogsStreamRetryHandler({
       authService,
       logger,
       maxRetries,
+      lifecycle,
       closeTracked: (wsClient, endpoint) => this.closeTracked(wsClient, endpoint),
       reconnect: (endpoint, options, retryCount) => this.connect(endpoint, options, retryCount),
     })
@@ -193,6 +206,8 @@ export class LogsStream {
    * @returns A function to close the WebSocket connection.
    */
   private async connect(endpoint: string, options: LogOptions, retryCount = 0): Promise<HandleCloseConnection> {
+    this.lifecycle.assertActive(`logs.connect(${endpoint})`)
+
     const interval = resolveLogInterval(options.interval)
 
     this.logger.debug(`Establishing WebSocket connection to: ${endpoint}`, 'LogsStream')
@@ -216,6 +231,7 @@ export class LogsStream {
    * Connects to the core logs (`/api/core/logs`).
    * @param options Connection options (callbacks, interval).
    * @returns A function to close the WebSocket connection.
+   * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    */
   async connectByCore(options: LogOptions) {
     this.logger.debug('Connecting to core logs WebSocket', 'LogsStream')
@@ -227,6 +243,7 @@ export class LogsStream {
    * @param nodeId The ID of the node whose logs should be accessed.
    * @param options Connection options (callbacks, interval).
    * @returns A function to close the WebSocket connection.
+   * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    */
   async connectByNode(nodeId: number | string, options: LogOptions) {
     this.logger.debug(`Connecting to node logs WebSocket for node ID: ${nodeId}`, 'LogsStream')


### PR DESCRIPTION
## Summary
- `destroy()` is now a terminal, idempotent shutdown: calling it twice is a no-op, and `authorize()`, `getAuthToken()`, `logs.connect*()`, and the webhook processing methods (`parseWebhook`/`handleWebhook`/`dispatch`) reject with the new `SdkDestroyedError` from then on. `webhook.on()`/`once()`/`off()` keep working, so unsubscribing after shutdown stays safe.
- Webhook listeners are cleared and the stored access token is dropped on `destroy()`; a WebSocket 403 reconnect already in flight can no longer open a new socket after shutdown resolves.
- Direct API calls (`sdk.user.*`, `sdk.node.*`, …) are not rejected by `destroy()` itself — the cleared token makes them fail with the panel's own 401 once re-authentication is attempted and rejected by the same guard.
- Docs: new ADR-0015, an `ARCHITECTURE.md` Lifecycle section, and a new [Lifecycle & Shutdown](https://ilmar7786.github.io/marzban-sdk/docs/advanced/lifecycle) guide on the docs site.
- This is the non-WS half of #84 — the reconnect state machine and per-stream `close()` race stay with #88, which will build on the same `Lifecycle` primitive introduced here.

Closes #84

BREAKING CHANGE: `destroy()` is now terminal. `authorize()`, `getAuthToken()`, `logs.connect*()`, and `webhook.parseWebhook()`/`handleWebhook()`/`dispatch()` throw or reject with `SdkDestroyedError` once `destroy()` has been called, instead of continuing to work.

## Test plan
- [x] `pnpm --filter marzban-sdk test:coverage` — 770 tests, 100% statements/branches/functions/lines
- [x] `pnpm --filter marzban-mcp test:coverage` — 381 tests, 100% coverage, unaffected by the change
- [x] `pnpm lint`, `pnpm types:check`, `pnpm format:check`, `pnpm build` across the whole monorepo
- [x] `pnpm --filter marzban-sdk-docs build` — new `advanced/lifecycle` page renders and its in-page anchor resolves