### PR TITLE
feat(sdk)!: WS log-stream public surface — lifecycle, replay, reconnect, header auth

### DIFF
--- a/apps/docs/content/docs/advanced/error-handling.mdx
+++ b/apps/docs/content/docs/advanced/error-handling.mdx
@@ -16,6 +16,7 @@ Error
     ├── HttpError            (code: NETWORK_HTTP_ERROR)
     ├── SdkDestroyedError    (code: SDK_DESTROYED)
     ├── WsOptionsError       (code: WS_OPTIONS_INVALID)
+    ├── WsError              (code: WS_HANDSHAKE_REJECTED | WS_AUTH_FAILED | WS_CONNECTION_LOST | WS_RETRIES_EXHAUSTED)
     └── WebhookError
         ├── WebhookSignatureError     (code: WEBHOOK_SIGNATURE_ERROR)
         ├── WebhookValidationError    (code: WEBHOOK_VALIDATION_ERROR)
@@ -49,7 +50,11 @@ class SdkError extends Error {
 | `CONFIG_INVALID` | `ConfigurationError` | Config fails Zod schema validation |
 | `NETWORK_HTTP_ERROR` | `HttpError` | HTTP request failed (4xx, 5xx, network timeout) |
 | `SDK_DESTROYED` | `SdkDestroyedError` | A guarded operation (`authorize()`, `logs.connect*()`, webhook processing, …) was called after [`sdk.destroy()`](/docs/advanced/lifecycle) |
-| `WS_OPTIONS_INVALID` | `WsOptionsError` | `LogOptions.interval` is outside the `0`–`10` range the panel accepts |
+| `WS_OPTIONS_INVALID` | `WsOptionsError` | `LogOptions.interval`/`replay`/`reconnect` is invalid |
+| `WS_HANDSHAKE_REJECTED` | `WsError` | The WebSocket handshake was rejected before the connection ever opened |
+| `WS_AUTH_FAILED` | `WsError` | Re-authenticating with a fresh token still failed to open the connection |
+| `WS_CONNECTION_LOST` | `WsError` | The connection was lost after opening (a transport drop) |
+| `WS_RETRIES_EXHAUSTED` | `WsError` | The reconnect budget ran out (or the [`reconnect` policy](/docs/realtime/websocket-logs#reconnect-behavior) gave up) before the stream reopened |
 | `WEBHOOK_SIGNATURE_ERROR` | `WebhookSignatureError` | Missing signature or HMAC mismatch |
 | `WEBHOOK_VALIDATION_ERROR` | `WebhookValidationError` | Webhook payload doesn't match expected schema |
 | `WEBHOOK_ENVIRONMENT_ERROR` | `WebhookEnvironmentError` | Signature verification called in a browser context |
@@ -82,6 +87,8 @@ import {
   isConfigurationError,
   isHttpError,
   isSdkDestroyedError,
+  isWsError,
+  isWsOptionsError,
   isWebhookSignatureError,
   isWebhookValidationError,
   isWebhookEnvironmentError,

--- a/apps/docs/content/docs/advanced/http-retry.mdx
+++ b/apps/docs/content/docs/advanced/http-retry.mdx
@@ -74,18 +74,18 @@ The SDK has a separate, built-in mechanism for 401 responses:
 
 This happens transparently — your code never sees the 401.
 
-## WebSocket retries
+## WebSocket reconnects
 
-WebSocket connections use the same `retries` value for **403 Forbidden** reconnections:
+WebSocket log streams don't use `retries` at all — they have their own `reconnect` policy: exponential backoff with jitter, bounded by a time budget (10 minutes by default) instead of an attempt count.
 
 ```ts
-const closeStream = await sdk.logs.connectByCore({
+const stream = await sdk.logs.connectByCore({
   onMessage: (data) => console.log(data),
-  onError: (event) => console.error('Max retries reached', event),
+  onError: (error) => console.error('Stream ended', error.code, error.message),
 })
 ```
 
-If the server returns `403` on a WebSocket connection, the SDK re-authenticates and retries up to `retries` times. After exhausting retries, the `onError` callback is invoked.
+If the connection drops after opening, the SDK re-authenticates and reconnects automatically until it succeeds or the budget runs out. A **failed first connect** rejects `connect*()` immediately by default (`reconnect.initial` opts into retrying that too). See [WebSocket Logs → Reconnect behavior](/docs/realtime/websocket-logs#reconnect-behavior) for the full policy, including the `config.reconnect` SDK-wide default and per-call overrides.
 
 ## Multiple SDK instances
 

--- a/apps/docs/content/docs/configuration/config-options.mdx
+++ b/apps/docs/content/docs/configuration/config-options.mdx
@@ -15,11 +15,12 @@ The `Config` object is passed to `createMarzbanSDK` or the `MarzbanSDK` construc
 | `token` | `string` | No | — | Existing JWT token. If provided, the SDK uses it directly instead of calling the login endpoint. |
 | `authenticateOnInit` | `boolean` | No | `true` | When `true`, `createMarzbanSDK` calls `authorize()` before returning. Set to `false` for deferred or manual auth. |
 | `timeout` | `number` | No | `30000` | HTTP request timeout in milliseconds. Pass `0` to disable (wait forever). |
-| `retries` | `number` | No | `3` | Number of automatic retries for failed HTTP requests and WebSocket reconnections. Uses exponential backoff. |
+| `retries` | `number` | No | `3` | Number of automatic retries for failed HTTP requests. Uses exponential backoff. WebSocket log streams don't use this — see `reconnect` below. |
 | `logger` | `false \| LoggerOptions \| Logger` | No | env-aware | Logging configuration. See [Logging](/docs/configuration/logging). |
 | `webhook` | `{ secret?: string }` | No | — | Webhook configuration. Set `secret` to enable HMAC-SHA256 signature verification. |
 | `httpAgent` | `HttpAgentLike` | No | — | Node.js `http.Agent` (or compatible) used for `http:` requests. Ignored in browsers. |
 | `httpsAgent` | `HttpAgentLike` | No | — | Node.js `https.Agent` (or compatible) used for `https:` requests and the WebSocket log stream. Ignored in browsers. See [Self-signed certificates](#self-signed-certificates--custom-ca) below. |
+| `reconnect` | `boolean \| object` | No | enabled | SDK-wide default WS reconnect policy — `LogOptions.reconnect` overrides it per call. `false` disables reconnecting entirely. See [WebSocket Logs → Reconnect behavior](/docs/realtime/websocket-logs#reconnect-behavior). |
 
 ## Minimal config
 
@@ -110,9 +111,9 @@ When `retries > 0`, failed HTTP requests are retried with **exponential backoff*
 Only safe methods (GET, HEAD, OPTIONS) are retried — see
 [HTTP & Retry](/docs/advanced/http-retry) for the full method/status breakdown.
 
-WebSocket reconnections after `403 Forbidden` also use the same `retries` limit.
+WebSocket log streams don't use `retries` — they have their own `reconnect` policy (backoff + a time budget instead of an attempt count). See [WebSocket Logs → Reconnect behavior](/docs/realtime/websocket-logs#reconnect-behavior).
 
-Set `retries: 0` to disable automatic retries.
+Set `retries: 0` to disable automatic HTTP retries.
 
 ## Validation errors
 

--- a/apps/docs/content/docs/realtime/websocket-logs.mdx
+++ b/apps/docs/content/docs/realtime/websocket-logs.mdx
@@ -1,56 +1,56 @@
 ---
 title: WebSocket Logs
-description: Stream live logs from the Marzban Xray core and individual nodes over WebSocket, with automatic token refresh and reconnection via `sdk.logs`.
+description: Stream live logs from the Marzban Xray core and individual nodes over WebSocket, with automatic reconnection, deduplication, and lifecycle callbacks via `sdk.logs`.
 ---
 
-`sdk.logs` provides live log streaming over WebSocket. It supports both the **core Xray process** and **individual node** logs, with automatic token refresh on `403 Forbidden`.
+`sdk.logs` provides live log streaming over WebSocket. It supports both the **core Xray process** and **individual node** logs, with automatic reconnection, token refresh, and duplicate-line suppression after a drop.
 
 ## How it works
 
 Each `connect*` call:
 1. Ensures the SDK has a valid token (re-authenticates if needed).
-2. Opens a WebSocket connection to the Marzban backend.
-3. Returns a **close function** — call it to terminate the connection.
+2. Opens a WebSocket connection to the Marzban backend — the promise resolves only once the socket is genuinely open.
+3. Returns a **stream handle**: callable to close the stream, plus an explicit `.close()` and a live `.state`.
 
-Active connections are tracked internally. `sdk.destroy()` closes all of them at once.
+If the connection drops after opening, the stream reconnects on its own (exponential backoff, bounded by a time budget) and reports it through `onReconnect`/`onOpen`. Active streams are tracked internally — `sdk.destroy()` closes all of them at once.
 
 ## Connect to core logs
 
 ```ts
-const closeStream = await sdk.logs.connectByCore({
+const stream = await sdk.logs.connectByCore({
   interval: 1, // polling interval in seconds (default: 1)
   onMessage: (data) => {
     console.log('[Core log]', data)
   },
-  onError: (event) => {
-    console.error('WebSocket error:', event)
+  onError: (error) => {
+    console.error('WebSocket error:', error.code, error.message)
   },
 })
 
-// Later, close the stream
-closeStream()
+// Later, close the stream — the handle is callable, or use .close()
+stream()
 ```
 
 ## Connect to node logs
 
 ```ts
-const closeStream = await sdk.logs.connectByNode(nodeId, {
+const stream = await sdk.logs.connectByNode(nodeId, {
   interval: 1,
   onMessage: (data) => {
     console.log(`[Node ${nodeId} log]`, data)
   },
-  onError: (event) => {
-    console.error('Node log error:', event)
+  onError: (error) => {
+    console.error('Node log error:', error.code, error.message)
   },
 })
 
-closeStream()
+stream.close()
 ```
 
 ## Multiple concurrent streams
 
 ```ts
-const [closeCore, closeNode1, closeNode2] = await Promise.all([
+const [core, node1, node2] = await Promise.all([
   sdk.logs.connectByCore({ onMessage: d => process.stdout.write(d) }),
   sdk.logs.connectByNode(1, { onMessage: d => process.stdout.write(d) }),
   sdk.logs.connectByNode(2, { onMessage: d => process.stdout.write(d) }),
@@ -64,33 +64,78 @@ await sdk.destroy()
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `onMessage` | `(data: any) => void` | required | Called on each incoming log line |
-| `onError` | `(event: ErrorEvent) => void` | — | Called after max retries are exhausted |
+| `onMessage` | `(data: any) => void` | required | Called on each incoming log line (already deduplicated per `replay`) |
+| `onError` | `(error: WsError) => void` | — | Called once, when the stream ends for good — a typed error, never a raw transport event |
+| `onOpen` | `() => void` | — | Called every time the stream reaches `open` — the first connect and each successful reconnect |
+| `onReconnect` | `(info: { attempt: number; downtimeMs: number }) => void` | — | Called when a dropped stream successfully reopens |
+| `onClose` | `(info: { code?: number; byCaller: boolean }) => void` | — | Called once, when the stream ends for good — only if it ever reached `open`. `byCaller` is `true` when you closed it, `false` when it died on its own |
 | `interval` | `number` | `1` | Polling interval in seconds. Must be `0`–`10` (fractional values allowed); `0` disables batching and streams each line as it arrives |
+| `replay` | `'all' \| 'dedup' \| 'skip'` | `'dedup'` | How to handle log lines the panel re-delivers after a reconnect — see [Deduplication after a reconnect](#deduplication-after-a-reconnect) |
+| `reconnect` | `boolean \| object` | enabled | Per-call override of the [reconnect policy](#reconnect-behavior) |
 
-`interval` is validated before a socket is opened — a value outside `0`–`10` throws a `WsOptionsError` synchronously instead of round-tripping to the panel, which would otherwise reject it as a generic `403` (see [Error handling](/docs/advanced/error-handling#error-codes-reference)).
+`interval`/`replay`/`reconnect` are validated before a socket is opened — an invalid value throws a `WsOptionsError` synchronously instead of round-tripping to the panel, which would otherwise reject an out-of-range `interval` as a generic `403` (see [Error handling](/docs/advanced/error-handling#error-codes-reference)).
 
-A throwing `onMessage` or `onError` is caught and logged rather than propagated — it can't crash your process or stop later messages from arriving.
+A throwing callback is caught and logged rather than propagated — it can't crash your process or stop later events from arriving.
 
-## 403 / auth retry behaviour
+`onClose` never fires for a first connect that fails: that's reported through the `connect*()` rejection alone. A self-inflicted end (the budget runs out, the panel refuses a fresh token) reports `onError` then `onClose({ byCaller: false })`; closing the stream yourself reports `onClose({ byCaller: true })` with no `onError`.
 
-If the server returns `403 Forbidden` on a WebSocket connection, the SDK:
+## Reconnect behavior
 
-1. Closes the errored socket.
-2. Re-authenticates using stored credentials.
-3. Opens a new socket with the fresh token.
-4. Repeats up to `config.retries` times (default: 3).
-5. Calls `onError` if all retries are exhausted.
+A dropped stream reconnects automatically: exponential backoff with jitter, bounded by a 10-minute time budget that resets after 30 seconds of stable uptime. A **failed first connect** rejects `connect*()` immediately by default, so a misconfigured `baseUrl` or a down panel fails loudly instead of hanging.
+
+Override it per call with `reconnect`:
+
+```ts
+await sdk.logs.connectByCore({
+  onMessage: data => console.log(data),
+  reconnect: {
+    initial: true,        // also retry a failed *first* connect
+    maxElapsedMs: Infinity, // never give up (default: 10 minutes)
+    minDelayMs: 500,
+    maxDelayMs: 20_000,
+    shouldReconnect: ({ attempt, elapsedMs, error }) => {
+      if (attempt > 20) return false // give up after 20 attempts
+      return true // or return a number to override the delay
+    },
+  },
+})
+
+// Or disable it entirely for one stream:
+await sdk.logs.connectByCore({ onMessage: data => console.log(data), reconnect: false })
+```
+
+Set an SDK-wide default instead of repeating it per call — `LogOptions.reconnect` still overrides it:
+
+```ts
+const sdk = await createMarzbanSDK({
+  baseUrl: 'https://panel.example.com',
+  username: 'admin',
+  password: 'secret',
+  reconnect: { maxElapsedMs: Infinity },
+})
+```
+
+## Deduplication after a reconnect
+
+The panel re-seeds every new connection from a shared buffer of its last ~100 log lines — a reconnect naturally re-delivers lines your `onMessage` already saw. `replay: 'dedup'` (the default) suppresses them: it tracks the last ~200 delivered lines and drops a leading run of already-seen ones after a reconnect, until the first genuinely new line. A line that legitimately repeats (a heartbeat, `"OK"`) is never dropped once the replay has actually been worked through.
+
+```ts
+// See every line, duplicates included
+await sdk.logs.connectByCore({ onMessage: data => console.log(data), replay: 'all' })
+
+// Drop every replayed message outright, until the first clean one
+await sdk.logs.connectByCore({ onMessage: data => console.log(data), replay: 'skip' })
+```
 
 ## Cleanup
 
 Always close streams when you no longer need them to avoid resource leaks:
 
 ```ts
-// Close a single stream
-const close = await sdk.logs.connectByCore({ onMessage: handler })
+// Close a single stream — the handle is callable, or use .close()
+const stream = await sdk.logs.connectByCore({ onMessage: handler })
 // ...
-close()
+stream()
 
 // Close all active streams + release other SDK resources
 await sdk.destroy()
@@ -127,6 +172,8 @@ The WebSocket client auto-detects the runtime:
 
 No configuration required for that detection — it's fully transparent, **unless** you set `httpsAgent`, which forces the `ws`-backed client outside the browser (see above) regardless of what's natively available.
 
+The access token also travels differently depending on which client is used: the `ws`-backed client sends it as an `Authorization: Bearer` header, so it never appears in the URL. The native `WebSocket` constructor has no headers option at all — a platform limit, not a gap in this SDK — so on that client (every browser, and Node.js 21+ without a configured `httpsAgent`) the token stays in the URL's `token` query parameter.
+
 ## React / frontend example
 
 ```tsx
@@ -140,9 +187,9 @@ function NodeLogViewer({ sdk, nodeId }: { sdk: MarzbanSDK; nodeId: number }) {
     sdk.logs
       .connectByNode(nodeId, {
         onMessage: (data) => console.log(data),
-        onError: (e) => console.error('Stream error', e),
+        onError: (error) => console.error('Stream error', error.code, error.message),
       })
-      .then(fn => { close = fn })
+      .then(stream => { close = stream.close })
 
     return () => { close?.() }
   }, [sdk, nodeId])

--- a/apps/docs/src/components/docs/type-glossary.ts
+++ b/apps/docs/src/components/docs/type-glossary.ts
@@ -167,12 +167,14 @@ export const typeGlossary: Record<string, TypeInfo> = {
 
   // ── Real-time logs ─────────────────────────────────────────────────────
   LogOptions: {
-    description: 'Options for a WebSocket log stream: onMessage, an optional onError, and a polling interval.',
+    description:
+      'Options for a WebSocket log stream: onMessage, lifecycle callbacks (onOpen/onReconnect/onClose/onError), interval, replay, and reconnect.',
     href: '/docs/realtime/websocket-logs#logoptions',
   },
-  ErrorEvent: {
+  WsError: {
     description:
-      "The runtime's global WebSocket error event, passed to a log stream's onError after retries are exhausted. A standard platform type (browser / Node `ws`), not an SDK type — so there's no SDK definition to link to.",
+      'Raised by a WS log stream instead of a raw transport event (codes WS_HANDSHAKE_REJECTED, WS_AUTH_FAILED, WS_CONNECTION_LOST, WS_RETRIES_EXHAUSTED). .url never contains the access token.',
+    href: '/docs/advanced/error-handling#error-codes-reference',
   },
 
   // ── Webhooks ───────────────────────────────────────────────────────────

--- a/docs/adr/0017-ws-public-stream-surface.md
+++ b/docs/adr/0017-ws-public-stream-surface.md
@@ -1,0 +1,104 @@
+# ADR-0017: WS stream public surface — replay, reconnect, and header auth
+
+Status: Accepted
+Date: 2026-09-04
+
+## Context
+
+[ADR-0016](./0016-ws-stream-lifecycle-and-reconnect.md) built the reconnect
+state machine as an internal default and explicitly deferred its public
+surface to [issue #89](https://github.com/Ilmar7786/marzban-sdk/issues/89):
+lifecycle callbacks, a `replay` option to deduplicate lines the panel
+re-delivers after a reconnect, a public `reconnect` policy, and sending the
+access token as a header instead of in the URL. Each of these turned out to
+need a real decision beyond "expose what's already there":
+
+- The panel's replay buffer has no cursor — there is nothing to dedupe
+  _against_ except content itself, which risks silently swallowing a
+  legitimately repeating log line (a heartbeat, `"OK"`).
+- `onClose` needed a definition of "once" that survives a flapping
+  connection, a caller-initiated close, and a first connect that never
+  opened at all.
+- A public `reconnect` option and the existing internal `tuning` test seam
+  both want to set the same timing knobs, for different reasons (a real
+  policy vs. compressing real windows for tests).
+- The panel accepts the token via `Authorization: Bearer` as an alternative
+  to the query string — but only one of the SDK's two transports can send a
+  custom header at all.
+
+## Decision
+
+**Replay dedup operates on lines, not messages, and only inside a window
+armed by a drop.** A batching `interval > 0` joins several lines into one
+message on the live stream; the panel's replay buffer has no such grouping,
+so a whole-message comparison would rarely match. `replay: 'dedup'`
+(default) keeps a ring of the last ~200 delivered lines and drops a leading
+run of already-seen lines after a reconnect; the first genuinely new line
+disarms the window, so nothing is suppressed once the replay has actually
+been worked through. A hard cap on lines scanned while armed forces a
+disarm regardless, so a stream of identical lines can never hold the window
+open forever. `replay: 'skip'` drops each replayed message outright until
+the first clean one; `replay: 'all'` disables the filter.
+
+**`onClose` fires at most once per logical stream, and only if it ever
+reached `open`.** A first connect that fails is reported through the
+`connect*()` rejection alone — the same "reported exactly once" invariant
+ADR-0016 established for `onError`. A self-inflicted end reports
+`onError` then `onClose({ byCaller: false })`; a caller-initiated `close()`
+(the handle, `close()`, or `sdk.destroy()`) reports `onClose({ byCaller:
+true })` with no `onError`.
+
+**The public `reconnect` policy and the internal `tuning` seam are layered,
+not merged.** `LogStream.tuning` is built as
+`{ ...DEFAULT_TUNING, ...reconnectPolicyToTuning(policy), ...tuning }` —
+only the policy's explicitly-set timing fields participate, and the
+internal seam (used by this package's own tests to avoid waiting out real
+windows) always wins. `reconnect.initial` retries a failed first connect
+through the same policy-gated loop a post-open drop uses, but still only
+ever rejects `connect*()` directly — never `onError`/`onClose` — since the
+stream never reached `open`. `reconnect.shouldReconnect` sits beside the
+reconnect budget rather than inside it: a hard-capped budget check happens
+independently of what `shouldReconnect` returns, and the documented escape
+hatch for "never give up" is `maxElapsedMs: Infinity`, not a callback that
+can outlast the budget.
+
+**The token moves to an `Authorization` header only on the `ws`-package
+transport.** The panel accepts `query_params.get("token") or
+headers.get("Authorization").removeprefix("Bearer ")` (verified against
+`gozargah/marzban:v0.8.4`), but the native `WebSocket` constructor
+(browsers, Deno, Bun, Node.js 21+) has no headers option at all — a
+platform limit, not a gap in this SDK. `core/ws/client/select-transport.ts`
+extracts the transport decision `WebSocketClient.resolve()` already made
+into a standalone, pure function, so `LogStream.attemptOnce()` can ask it
+_before_ building the URL — deciding the transport first, then whether the
+token goes in the query or the header, rather than building a URL that
+might not match what `resolve()` picks. Subprotocol smuggling (the
+Kubernetes `base64url.bearer.authorization.k8s.io.<token>` pattern) was
+considered and rejected: the panel only ever reads the query parameter or
+the `Authorization` header, so a third encoding would add complexity this
+API surface has no use for.
+
+## Consequences
+
+- **Breaking** (`sdk-v4.0.0`, same release as ADR-0016): `LogOptions.onError`
+  receives a `WsError` instead of a raw transport event; `connect*()`
+  resolves to a callable stream handle (`{ (): void; close(): void; readonly
+state }`) instead of a bare close function — source-compatible, since the
+  handle is still callable; `replay: 'dedup'` is on by default, so a
+  consumer that relied on seeing every replayed line (unlikely, but
+  possible) now has to opt into `replay: 'all'`.
+- `LogStreamState`, `WsCloseInfo`, `WsReconnectInfo`, `ReplayMode`,
+  `ReconnectOption`/`ReconnectOptions`/`ShouldReconnectContext` are now
+  public API. `LogStream`, `LogStreamTuning`, and everything under
+  `core/ws/utils/` except `configurationUrlWs` stay internal — the branchy
+  parts of replay/reconnect resolution live there specifically so they can
+  be tested as pure functions instead of through the state machine.
+- On the native transport, the token still travels in the URL query string
+  — this ADR does not (and cannot) change that; `WsError.url`'s redaction
+  guarantee is unaffected either way, but on the `ws`-package transport it
+  becomes a no-op-by-absence rather than an active redaction, which is why
+  the test suite asserts "not the real token" on both transports rather
+  than "redacted" specifically.
+- `config.reconnect` (SDK-wide default) and `LogOptions.reconnect`
+  (per-call) don't merge field-by-field — a per-call value fully replaces
+  the SDK-wide one, the same model `interval` and `replay` already use.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,3 +57,4 @@ What this enables, what it costs.
 | [0014](./0014-git-cliff-unreleased-not-latest.md)                    | git-cliff uses `--unreleased`, tags pin to the commit CI ran on     |
 | [0015](./0015-sdk-destroy-terminal-lifecycle.md)                     | `MarzbanSDK.destroy()` is a terminal lifecycle transition           |
 | [0016](./0016-ws-stream-lifecycle-and-reconnect.md)                  | WebSocket stream lifecycle and reconnect policy                     |
+| [0017](./0017-ws-public-stream-surface.md)                           | WS stream public surface — replay, reconnect, and header auth       |

--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -425,6 +425,28 @@ ambiguous keeps retrying within a time budget, so a restarting panel is not
 mistaken for a rejection. See
 [ADR-0016](./adr/0016-ws-stream-lifecycle-and-reconnect.md).
 
+## WebSocket log endpoints accept the token as a header, not just a query param
+
+**Verified against:** `gozargah/marzban:v0.8.4` source
+(`app/routers/core.py`/`node.py`):
+
+```py
+token = websocket.query_params.get("token") or websocket.headers.get(
+    "Authorization", ""
+).removeprefix("Bearer ")
+```
+
+The query parameter wins if both are present; the header is the fallback.
+`LogStream` (`core/ws/log-stream.ts`) sends `Authorization: Bearer <token>`
+on the `ws`-package transport instead of the query string, so the token
+never lands in a reverse proxy's access log on that path — verified
+directly against the running panel: the access log shows
+`"WebSocket /api/core/logs?interval=1" [accepted]`, no `token=`. The native
+`WebSocket` constructor has no headers option at all, so on that transport
+(every browser, and Node.js 21+ without a configured `httpsAgent`) the token
+still goes in the query string — a platform limit, not a choice. See
+[ADR-0017](./adr/0017-ws-public-stream-surface.md).
+
 ## Every new WebSocket log connection replays up to the last 100 log lines
 
 **Verified against:** `gozargah/marzban:v0.8.4`, `local/marzban/`.
@@ -442,5 +464,9 @@ means every reconnect re-delivers already-seen lines, and
 policy makes reconnects far more common than before.
 
 **Workaround:** client-side deduplication of recently delivered lines —
-[issue #89](https://github.com/Ilmar7786/marzban-sdk/issues/89)'s
-`replay: 'dedup'`, which is why that is the intended default.
+`LogOptions.replay: 'dedup'` (the default since `sdk-v4.0.0`), which tracks
+the last ~200 delivered lines and drops a leading run of already-seen ones
+after a reconnect. Per-line, not per-message: a batching `interval > 0`
+joins several lines into one message on the live stream, but the panel's
+replay buffer has no such grouping, so the two never line up. See
+[ADR-0017](./adr/0017-ws-public-stream-surface.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,9 +161,18 @@ timeout and a 10-minute reconnect budget.
 Small pure pieces live in `core/ws/utils/` next to `configuration-url-ws.ts`
 — `log-interval.ts` (validates `interval` against the panel's `0`–`10` range,
 throwing `WsOptionsError`), `close-quietly.ts` (closes a socket, collecting
-rather than propagating a throw from `close()` itself), and `ws-error.ts`
+rather than propagating a throw from `close()` itself), `ws-error.ts`
 (reads the handshake's HTTP status out of the error message, when the
-transport reported one). None are re-exported from `utils/index.ts` — only
+transport reported one), `replay.ts` (the `replay: 'dedup'/'skip'` line
+filter — every mode × armed/not-armed/hard-cap branch lives in
+`replay.test.ts` rather than in the state machine), and
+`reconnect-policy.ts`/`reconnect-decision.ts` (validating and resolving the
+public `reconnect` option, and the `shouldReconnect`/budget verdict —
+likewise fully covered as pure functions rather than through `LogStream`).
+`core/ws/client/select-transport.ts` is the same idea one level up: which
+transport `WebSocketClient.resolve()` picks, extracted so `LogStream` can
+ask the identical question before building a URL or headers for it. None
+are re-exported from `utils/index.ts`/`client/index.ts` — only
 `configurationUrlWs` is; everything else is imported by its own file path so
 it stays out of the package's public API.
 

--- a/packages/sdk/src/config/config.ts
+++ b/packages/sdk/src/config/config.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4'
 
 import { HttpAgentLike } from '@/common'
+import { reconnectOptionSchema } from '@/core/ws/utils/reconnect-policy'
 
 import { loggerConfigSchema } from './config.logger'
 import { webhookSchema } from './config.webhook'
@@ -27,6 +28,7 @@ export const configSchema = z.object({
   webhook: webhookSchema.optional(),
   httpAgent: httpAgentSchema.optional(),
   httpsAgent: httpAgentSchema.optional(),
+  reconnect: reconnectOptionSchema.optional(),
 })
 
 /**
@@ -45,6 +47,7 @@ export const configSchema = z.object({
  * @property {object} [webhook] - Webhook handling options (e.g. signature `secret`).
  * @property {HttpAgentLike} [httpAgent] - Node.js `http.Agent` (or compatible) used for `http:` requests. Ignored in browsers.
  * @property {HttpAgentLike} [httpsAgent] - Node.js `https.Agent` (or compatible) used for `https:` requests and the WebSocket log stream — e.g. `new https.Agent({ ca: readFileSync('ca.pem') })` to trust a self-signed panel certificate. Ignored in browsers.
+ * @property {boolean | object} [reconnect] - SDK-wide default WS reconnect policy — `LogOptions.reconnect` overrides it per call. `false` disables reconnecting entirely; an options object sets `initial`/`maxElapsedMs`/`stableAfterMs`/`minDelayMs`/`maxDelayMs`/`shouldReconnect`.
  */
 export type Config = z.input<typeof configSchema>
 export type ValidatedConfig = z.infer<typeof configSchema>

--- a/packages/sdk/src/config/config.ts
+++ b/packages/sdk/src/config/config.ts
@@ -40,7 +40,7 @@ export const configSchema = z.object({
  * @property {string} username - Username for authentication (non-empty).
  * @property {string} password - Password for authentication (non-empty).
  * @property {number} [timeout=30000] - Request timeout in milliseconds. `0` disables the timeout (wait forever).
- * @property {number} [retries=3] - Number of automatic retries for failed HTTP requests and WS reconnections.
+ * @property {number} [retries=3] - Number of automatic retries for failed HTTP requests. WS log streaming uses its own `reconnect` policy instead.
  * @property {string} [token] - Optional JWT token for authorization. If provided, SDK will use it instead of logging in.
  * @property {boolean} [authenticateOnInit=true] - If false, SDK will not authenticate on instantiation (call `authorize()` manually).
  * @property {false | LoggerOptions | Logger} [logger] - Logging configuration: `false` to disable, options for the built-in logger, or a custom logger.

--- a/packages/sdk/src/config/defaults.ts
+++ b/packages/sdk/src/config/defaults.ts
@@ -74,3 +74,18 @@ export const WS_RECONNECT_BUDGET_MS = 600_000
  * reconnect attempt with a budget already exhausted by earlier flapping.
  */
 export const WS_STABLE_AFTER_MS = 30_000
+
+/**
+ * Default `LogOptions.replay` mode. The panel seeds every new WS connection
+ * from a shared `deque(maxlen=100)` (see docs/marzban-quirks.md), so a
+ * reconnect re-delivers up to 100 already-seen lines by default — `'dedup'`
+ * suppresses that.
+ */
+export const DEFAULT_WS_REPLAY = 'dedup'
+
+/**
+ * Size of the ring buffer a `'dedup'`/`'skip'` replay filter checks incoming
+ * lines against after a reconnect. Larger than the panel's own 100-line
+ * buffer above, so a full replay is never partially missed.
+ */
+export const WS_REPLAY_BUFFER_LINES = 200

--- a/packages/sdk/src/core/MarzbanSDK.ts
+++ b/packages/sdk/src/core/MarzbanSDK.ts
@@ -155,6 +155,7 @@ export class MarzbanSDK {
       logger: this._logger,
       httpsAgent: this._config.httpsAgent,
       lifecycle: this._lifecycle,
+      reconnect: this._config.reconnect,
     })
     this.webhook = new WebhookManager({ ...this._config.webhook, logger: this._logger, lifecycle: this._lifecycle })
 

--- a/packages/sdk/src/core/ws/client/base-websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/base-websocket-client.ts
@@ -27,6 +27,13 @@ export interface WebSocketClientOptions {
    * concept of a custom agent, so {@link BrowserWebSocketClient} ignores it.
    */
   agent?: HttpAgentLike
+  /**
+   * Request headers for the WebSocket upgrade. Only honored by
+   * {@link NodeWebSocketClient} — the native `WebSocket` constructor
+   * (browsers, Deno, Bun, Node.js 21+) has no headers option at all, a
+   * platform limit {@link BrowserWebSocketClient} cannot work around.
+   */
+  headers?: Record<string, string>
 }
 
 type BufferedListener = { event: keyof WebSocketEventMap; listener: (event: AnyType) => void }
@@ -36,6 +43,7 @@ export abstract class BaseWebSocketClient {
   protected url: string
   protected protocols?: string | string[]
   protected agent?: HttpAgentLike
+  protected headers?: Record<string, string>
 
   private pendingListeners: BufferedListener[] = []
   private pendingClose?: { code?: number; reason?: string }
@@ -44,6 +52,7 @@ export abstract class BaseWebSocketClient {
     this.url = url
     this.protocols = protocols
     this.agent = options?.agent
+    this.headers = options?.headers
   }
 
   /** Override to await whatever the transport needs before construction (e.g. a lazy `import`). */

--- a/packages/sdk/src/core/ws/client/node-websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/node-websocket-client.ts
@@ -16,8 +16,12 @@ export class NodeWebSocketClient extends BaseWebSocketClient {
     const NodeWebSocket = this.wsConstructor!
     // The `ws` socket is EventTarget-compatible (addEventListener/send/close/
     // readyState) but its DOM typings differ, so we adapt it structurally —
-    // `agent` (our structural HttpAgentLike, not ws's own Agent type) the
-    // same way. `agent: undefined` when unset behaves identically to omitting it.
-    return new NodeWebSocket(this.url, this.protocols, { agent: this.agent as AnyType }) as AnyType as WebSocketLike
+    // `agent` (our structural HttpAgentLike, not ws's own Agent type) and
+    // `headers` the same way. Either being `undefined` when unset behaves
+    // identically to omitting it.
+    return new NodeWebSocket(this.url, this.protocols, {
+      agent: this.agent as AnyType,
+      headers: this.headers,
+    }) as AnyType as WebSocketLike
   }
 }

--- a/packages/sdk/src/core/ws/client/select-transport.test.ts
+++ b/packages/sdk/src/core/ws/client/select-transport.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { selectWsTransportKind, transportSupportsHeaders } from './select-transport'
+
+describe('selectWsTransportKind', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('picks native when a native WebSocket is available and no agent is set', () => {
+    vi.stubGlobal('WebSocket', class {})
+
+    expect(selectWsTransportKind()).toBe('native')
+    expect(selectWsTransportKind({})).toBe('native')
+  })
+
+  it('falls back to the ws package when there is no native WebSocket', () => {
+    vi.stubGlobal('WebSocket', undefined)
+
+    expect(selectWsTransportKind()).toBe('ws-package')
+  })
+
+  it('forces the ws package when an agent is configured outside the browser, even with a native WebSocket', () => {
+    vi.stubGlobal('WebSocket', class {})
+
+    expect(selectWsTransportKind({ agent: { destroy: vi.fn() } })).toBe('ws-package')
+  })
+
+  it('ignores the agent and stays on native inside the browser', () => {
+    vi.stubGlobal('WebSocket', class {})
+    vi.stubGlobal('window', { document: {} })
+
+    expect(selectWsTransportKind({ agent: { destroy: vi.fn() } })).toBe('native')
+  })
+})
+
+describe('transportSupportsHeaders', () => {
+  it('is true only for the ws package — the native WebSocket constructor has no headers option', () => {
+    expect(transportSupportsHeaders('ws-package')).toBe(true)
+    expect(transportSupportsHeaders('native')).toBe(false)
+  })
+})

--- a/packages/sdk/src/core/ws/client/select-transport.ts
+++ b/packages/sdk/src/core/ws/client/select-transport.ts
@@ -1,0 +1,26 @@
+import { hasNativeWebSocket, isBrowser } from '@/common'
+
+import type { WebSocketClientOptions } from './base-websocket-client'
+
+export type WsTransportKind = 'native' | 'ws-package'
+
+/**
+ * Which transport {@link WebSocketClient.resolve} will pick for these
+ * options — computed independently of any URL, so a caller that needs to
+ * decide something about the URL or headers based on the transport (see
+ * `LogStream.attemptOnce`) can ask this *before* building either, on the
+ * exact same inputs `resolve()` itself uses. One function, two call sites:
+ * they can never disagree.
+ */
+export const selectWsTransportKind = (options?: WebSocketClientOptions): WsTransportKind => {
+  const needsAgentCapableClient = Boolean(options?.agent) && !isBrowser()
+
+  return needsAgentCapableClient || !hasNativeWebSocket() ? 'ws-package' : 'native'
+}
+
+/**
+ * Only the `ws` package can set request headers on the WebSocket upgrade —
+ * the native `WebSocket` constructor (browsers, Deno, Bun, Node.js 21+) has
+ * no headers option at all. A platform limit, not a gap in this SDK.
+ */
+export const transportSupportsHeaders = (kind: WsTransportKind): boolean => kind === 'ws-package'

--- a/packages/sdk/src/core/ws/client/websocket-client.test.ts
+++ b/packages/sdk/src/core/ws/client/websocket-client.test.ts
@@ -120,6 +120,54 @@ describe('WebSocketClient', () => {
     expect(receivedOptions).toEqual({ agent })
   })
 
+  it('forwards headers to the ws-backed client', async () => {
+    // No native WebSocket — the simplest way to force NodeWebSocketClient
+    // without an agent, so this test isolates headers specifically.
+    delete (globalThis as AnyType).WebSocket
+
+    let receivedOptions: AnyType
+    class FakeWs {
+      public readyState = 1
+      addEventListener = vi.fn()
+      constructor(
+        public url: string,
+        public protocols: string | string[] | undefined,
+        options: AnyType
+      ) {
+        receivedOptions = options
+      }
+    }
+    vi.doMock('ws', () => ({ default: FakeWs }))
+
+    const { WebSocketClient } = await import('./websocket-client')
+    const headers = { Authorization: 'Bearer token' }
+    const client = await WebSocketClient.create('wss://example.com', undefined, { headers })
+
+    expect(client.constructor.name).toBe('NodeWebSocketClient')
+    expect(receivedOptions).toEqual({ headers })
+  })
+
+  it('cannot forward headers to the browser-backed client — the native WebSocket constructor has no options parameter', async () => {
+    let receivedArgs: unknown[] = []
+    class FakeWebSocket {
+      public readyState = 1
+      addEventListener = vi.fn()
+      constructor(...args: unknown[]) {
+        receivedArgs = args
+      }
+    }
+    ;(globalThis as AnyType).WebSocket = FakeWebSocket
+
+    const { WebSocketClient } = await import('./websocket-client')
+    const headers = { Authorization: 'Bearer token' }
+    const client = await WebSocketClient.create('wss://example.com', 'proto', { headers })
+
+    expect(client.constructor.name).toBe('BrowserWebSocketClient')
+    // Only (url, protocols) ever reach the native constructor — structurally
+    // impossible for headers to leak through, not just unused.
+    expect(receivedArgs).toEqual(['wss://example.com', 'proto'])
+  })
+
   it('ignores the agent and still uses BrowserWebSocketClient in the browser', async () => {
     class FakeWebSocket {
       public readyState = 1

--- a/packages/sdk/src/core/ws/client/websocket-client.ts
+++ b/packages/sdk/src/core/ws/client/websocket-client.ts
@@ -1,8 +1,7 @@
-import { hasNativeWebSocket, isBrowser } from '@/common'
-
 import { BaseWebSocketClient, WebSocketClientOptions } from './base-websocket-client'
 import { BrowserWebSocketClient } from './browser-websocket-client'
 import { NodeWebSocketClient } from './node-websocket-client'
+import { selectWsTransportKind } from './select-transport'
 
 export class WebSocketClient {
   /**
@@ -23,11 +22,14 @@ export class WebSocketClient {
    * browser the agent is structurally impossible to honor and is silently
    * ignored here — this class has no logger of its own, so callers that want
    * to warn their users do so themselves (see `LogsStream`).
+   *
+   * The decision itself lives in {@link selectWsTransportKind}, so a caller
+   * that needs to know the transport ahead of building a URL or headers for
+   * it (see `LogStream.attemptOnce`) evaluates the exact same function on
+   * the exact same inputs — it can never disagree with what this resolves to.
    */
   static resolve(url: string, protocols?: string | string[], options?: WebSocketClientOptions): BaseWebSocketClient {
-    const needsAgentCapableClient = Boolean(options?.agent) && !isBrowser()
-
-    return needsAgentCapableClient || !hasNativeWebSocket()
+    return selectWsTransportKind(options) === 'ws-package'
       ? new NodeWebSocketClient(url, protocols, options)
       : new BrowserWebSocketClient(url, protocols, options)
   }

--- a/packages/sdk/src/core/ws/index.ts
+++ b/packages/sdk/src/core/ws/index.ts
@@ -1,3 +1,4 @@
 export * from './client'
+export type { LogStreamState } from './log-stream'
 export * from './logs-stream'
 export * from './utils'

--- a/packages/sdk/src/core/ws/log-stream.test.ts
+++ b/packages/sdk/src/core/ws/log-stream.test.ts
@@ -83,6 +83,7 @@ describe('LogStream', () => {
       endpoint: '/api/core/logs',
       interval: 1,
       replay: 'dedup',
+      reconnect: { enabled: true, initial: false },
       handlers: { onMessage: vi.fn(), onError: vi.fn() },
       basePath: 'https://panel.example.com',
       authService,
@@ -358,6 +359,106 @@ describe('LogStream', () => {
       expect(socket.close).toHaveBeenCalled()
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('handshake timed out'), 'LogsStream')
       expect(isWsError(error)).toBe(true)
+    })
+  })
+
+  describe('reconnect.initial', () => {
+    it('retries a failed first connect through the same policy-gated loop a post-open drop uses, and eventually opens', async () => {
+      const stream = createStream({
+        reconnect: { enabled: true, initial: true },
+        tuning: { backoffBaseMs: 1, backoffMaxMs: 1 },
+      })
+      const opening = stream.open()
+
+      // The built-in "one re-auth retry" for a first connect — both fail.
+      ;(await waitForSocket(0)).emit('error', { message: '' })
+      ;(await waitForSocket(1)).emit('error', { message: '' })
+
+      // reconnect.initial kicks in: a further attempt through the loop succeeds.
+      ;(await waitForSocket(2)).emit('open')
+
+      await opening
+      expect(stream.state).toBe('open')
+    })
+
+    it('rejects connect*() when the initial retry loop exhausts its budget, without ever calling onClose', async () => {
+      const onClose = vi.fn()
+      const stream = createStream({
+        handlers: { onMessage: vi.fn(), onClose },
+        reconnect: { enabled: true, initial: true },
+        tuning: { backoffBaseMs: 1, backoffMaxMs: 1, reconnectBudgetMs: 0 },
+      })
+      const opening = stream.open().catch((err: unknown) => err)
+
+      ;(await waitForSocket(0)).emit('error', { message: '' })
+      ;(await waitForSocket(1)).emit('error', { message: '' })
+
+      const error = await opening
+      expect(isWsError(error) && error.code).toBe('WS_RETRIES_EXHAUSTED')
+      expect(onClose).not.toHaveBeenCalled()
+      expect(stream.state).toBe('closed')
+    })
+
+    it('closes without entering the retry loop when destroyed exactly as the first connect fails', async () => {
+      const stream = createStream({ reconnect: { enabled: true, initial: true } })
+      const opening = stream.open().catch((err: unknown) => err)
+
+      ;(await waitForSocket(0)).emit('error', { message: '' })
+      const second = await waitForSocket(1)
+      lifecycle.markDestroyed()
+      second.emit('error', { message: '' })
+
+      const error = await opening
+      expect(error).toBeInstanceOf(Error)
+      // No retry attempt was made — only the two built-in attempts happened.
+      expect(sockets).toHaveLength(2)
+    })
+  })
+
+  describe('reconnect option escape hatches', () => {
+    it('reconnect: false ends the stream at the first drop without opening a replacement socket', async () => {
+      const onError = vi.fn()
+      const onClose = vi.fn()
+      await openStream({
+        handlers: { onMessage: vi.fn(), onError, onClose },
+        reconnect: { enabled: false, initial: false },
+      })
+
+      sockets[0]!.emit('close', { code: 1006 })
+
+      await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
+      expect(sockets).toHaveLength(1)
+      const error = onError.mock.calls[0]![0]
+      expect(isWsError(error) && error.code).toBe('WS_CONNECTION_LOST')
+      expect(onClose).toHaveBeenCalledExactlyOnceWith({ code: 1006, byCaller: false })
+    })
+
+    it('shouldReconnect returning false stops the loop at the first attempt, without sleeping or opening a replacement socket', async () => {
+      const shouldReconnect = vi.fn().mockReturnValue(false)
+      const onError = vi.fn()
+      await openStream({
+        handlers: { onMessage: vi.fn(), onError },
+        reconnect: { enabled: true, initial: false, shouldReconnect },
+      })
+
+      sockets[0]!.emit('close', { code: 1006 })
+
+      await vi.waitFor(() => expect(onError).toHaveBeenCalled())
+      expect(shouldReconnect).toHaveBeenCalledOnce()
+      expect(sleep).not.toHaveBeenCalled()
+      expect(sockets).toHaveLength(1)
+    })
+
+    it('shouldReconnect returning a number overrides the computed backoff delay', async () => {
+      const shouldReconnect = vi.fn().mockReturnValue(4_321)
+      await openStream({
+        handlers: { onMessage: vi.fn() },
+        reconnect: { enabled: true, initial: false, shouldReconnect },
+      })
+
+      sockets[0]!.emit('close', { code: 1006 })
+
+      await vi.waitFor(() => expect(sleep).toHaveBeenCalledWith(4_321))
     })
   })
 

--- a/packages/sdk/src/core/ws/log-stream.test.ts
+++ b/packages/sdk/src/core/ws/log-stream.test.ts
@@ -82,6 +82,7 @@ describe('LogStream', () => {
     return new LogStream({
       endpoint: '/api/core/logs',
       interval: 1,
+      replay: 'dedup',
       handlers: { onMessage: vi.fn(), onError: vi.fn() },
       basePath: 'https://panel.example.com',
       authService,
@@ -502,6 +503,47 @@ describe('LogStream', () => {
       releaseSleep()
 
       await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    })
+  })
+
+  describe('replay', () => {
+    it('suppresses a message replayed after a reconnect by default (dedup)', async () => {
+      const onMessage = vi.fn()
+      const stream = await openStream({ handlers: { onMessage }, tuning: { backoffBaseMs: 1, backoffMaxMs: 1 } })
+
+      sockets[0]!.emit('message', { data: 'line one' })
+
+      sockets[0]!.emit('close', { code: 1006 })
+      const replacement = await waitForSocket(1)
+      replacement.emit('open')
+      await vi.waitFor(() => expect(stream.state).toBe('open'))
+
+      // The panel re-delivers the same buffered line after reconnecting.
+      replacement.emit('message', { data: 'line one' })
+      replacement.emit('message', { data: 'a genuinely new line' })
+
+      await vi.waitFor(() => expect(onMessage).toHaveBeenCalledWith('a genuinely new line'))
+      expect(onMessage.mock.calls).toEqual([['line one'], ['a genuinely new line']])
+    })
+
+    it('delivers a replayed duplicate unfiltered when replay is "all"', async () => {
+      const onMessage = vi.fn()
+      const stream = await openStream({
+        handlers: { onMessage },
+        replay: 'all',
+        tuning: { backoffBaseMs: 1, backoffMaxMs: 1 },
+      })
+
+      sockets[0]!.emit('message', { data: 'line one' })
+
+      sockets[0]!.emit('close', { code: 1006 })
+      const replacement = await waitForSocket(1)
+      replacement.emit('open')
+      await vi.waitFor(() => expect(stream.state).toBe('open'))
+
+      replacement.emit('message', { data: 'line one' })
+
+      await vi.waitFor(() => expect(onMessage.mock.calls).toEqual([['line one'], ['line one']]))
     })
   })
 

--- a/packages/sdk/src/core/ws/log-stream.test.ts
+++ b/packages/sdk/src/core/ws/log-stream.test.ts
@@ -88,8 +88,10 @@ describe('LogStream', () => {
       logger,
       lifecycle,
       onClosed,
-      tuning: { now: () => clock, sleep, ...overrides.tuning },
       ...overrides,
+      // Merged last: an override that only sets e.g. backoffBaseMs must not
+      // silently drop the fake now/sleep and fall back to real timers.
+      tuning: { now: () => clock, sleep, ...overrides.tuning },
     })
   }
 
@@ -469,11 +471,14 @@ describe('LogStream', () => {
       await opening
 
       // A close with no event payload at all — the terminal report still has
-      // to carry something for `onError`.
+      // to be a well-formed WsError even with nothing to forward.
       sockets[0]!.emit('close', undefined)
 
       await vi.waitFor(() => expect(onError).toHaveBeenCalled())
-      expect(onError.mock.calls[0]![0]).toMatchObject({ type: 'error' })
+      const error = onError.mock.calls[0]![0]
+      expect(isWsError(error) && error.code).toBe('WS_RETRIES_EXHAUSTED')
+      expect(isWsError(error) && error.phase).toBe('connection')
+      expect(isWsError(error) && error.details?.event).toBeUndefined()
       expect(stream.state).toBe('closed')
     })
 
@@ -497,6 +502,145 @@ describe('LogStream', () => {
       releaseSleep()
 
       await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    })
+  })
+
+  describe('lifecycle callbacks', () => {
+    it('calls onOpen once on the first connect', async () => {
+      const onOpen = vi.fn()
+      await openStream({ handlers: { onMessage: vi.fn(), onOpen } })
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onOpen again, and onReconnect with the attempt and downtime, on a successful reconnect', async () => {
+      const onOpen = vi.fn()
+      const onReconnect = vi.fn()
+      const stream = await openStream({
+        handlers: { onMessage: vi.fn(), onOpen, onReconnect },
+        tuning: { backoffBaseMs: 1, backoffMaxMs: 1 },
+      })
+      onOpen.mockClear()
+
+      sockets[0]!.emit('close', { code: 1006 })
+      clock += 5_000
+      ;(await waitForSocket(1)).emit('open')
+      await vi.waitFor(() => expect(stream.state).toBe('open'))
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onReconnect).toHaveBeenCalledExactlyOnceWith({ attempt: 1, downtimeMs: 5_000 })
+      // onOpen reports the state transition before onReconnect reports how it got there.
+      expect(onOpen.mock.invocationCallOrder[0]).toBeLessThan(onReconnect.mock.invocationCallOrder[0]!)
+    })
+
+    it('calls onClose({ byCaller: true }) exactly once when the caller closes an open stream', async () => {
+      const onClose = vi.fn()
+      const stream = await openStream({ handlers: { onMessage: vi.fn(), onClose } })
+
+      stream.close()
+      stream.close()
+
+      expect(onClose).toHaveBeenCalledExactlyOnceWith({ byCaller: true })
+    })
+
+    it('never calls onClose for a first connect that fails without ever opening', async () => {
+      const onClose = vi.fn()
+      const stream = createStream({ handlers: { onMessage: vi.fn(), onClose } })
+      const opening = stream.open().catch((error: unknown) => error)
+
+      ;(await waitForSocket(0)).emit('error', { message: '' })
+      ;(await waitForSocket(1)).emit('error', { message: '' })
+
+      expect(isWsError(await opening)).toBe(true)
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('never calls onClose when destroyed while the handshake is in flight', async () => {
+      let releaseAuth: () => void = () => {}
+      authService.waitForCurrentAuth = vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            releaseAuth = resolve
+          })
+      )
+      const onClose = vi.fn()
+      const stream = createStream({ handlers: { onMessage: vi.fn(), onClose } })
+      const opening = stream.open()
+
+      lifecycle.markDestroyed()
+      releaseAuth()
+
+      await expect(opening).rejects.toThrow()
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('calls onError then onClose({ byCaller: false }) in order when the stream terminates itself', async () => {
+      const onError = vi.fn()
+      const onClose = vi.fn()
+      const stream = createStream({
+        handlers: { onMessage: vi.fn(), onError, onClose },
+        tuning: { backoffBaseMs: 1, backoffMaxMs: 1, reconnectBudgetMs: 0 },
+      })
+      const opening = stream.open()
+      ;(await waitForSocket(0)).emit('open')
+      await opening
+
+      sockets[0]!.emit('close', { code: 1006 })
+
+      await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
+      expect(onError).toHaveBeenCalledTimes(1)
+      // closeCode carries over from the drop that started this reconnect loop.
+      expect(onClose).toHaveBeenCalledExactlyOnceWith({ code: 1006, byCaller: false })
+      expect(onError.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0]!)
+      expect(stream.state).toBe('closed')
+    })
+
+    it('logs rather than throws when onOpen throws', async () => {
+      const onOpen = vi.fn(() => {
+        throw new Error('onOpen boom')
+      })
+      await openStream({ handlers: { onMessage: vi.fn(), onOpen } })
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('onOpen callback threw'),
+        expect.any(Error),
+        'LogsStream'
+      )
+    })
+
+    it('logs rather than throws when onReconnect throws', async () => {
+      const onReconnect = vi.fn(() => {
+        throw new Error('onReconnect boom')
+      })
+      const stream = await openStream({
+        handlers: { onMessage: vi.fn(), onReconnect },
+        tuning: { backoffBaseMs: 1, backoffMaxMs: 1 },
+      })
+
+      sockets[0]!.emit('close', { code: 1006 })
+      ;(await waitForSocket(1)).emit('open')
+      await vi.waitFor(() => expect(stream.state).toBe('open'))
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('onReconnect callback threw'),
+        expect.any(Error),
+        'LogsStream'
+      )
+    })
+
+    it('logs rather than throws when onClose throws', async () => {
+      const onClose = vi.fn(() => {
+        throw new Error('onClose boom')
+      })
+      const stream = await openStream({ handlers: { onMessage: vi.fn(), onClose } })
+
+      stream.close()
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('onClose callback threw'),
+        expect.any(Error),
+        'LogsStream'
+      )
     })
   })
 })

--- a/packages/sdk/src/core/ws/log-stream.ts
+++ b/packages/sdk/src/core/ws/log-stream.ts
@@ -16,6 +16,8 @@ import { BaseWebSocketClient, WebSocketClient } from './client'
 import type { LogOptions, WsCloseInfo, WsReconnectInfo } from './logs-stream'
 import { configurationUrlWs } from './utils'
 import { closeQuietly } from './utils/close-quietly'
+import { decideReconnect } from './utils/reconnect-decision'
+import { reconnectPolicyToTuning, type ResolvedReconnectPolicy } from './utils/reconnect-policy'
 import { createReplayFilter, type ReplayFilter, type ReplayMode } from './utils/replay'
 import { extractWsHandshakeStatus, getWsErrorMessage } from './utils/ws-error'
 
@@ -44,6 +46,8 @@ export interface LogStreamOptions {
   interval: number
   /** Already validated by `resolveReplayMode`. */
   replay: ReplayMode
+  /** Already validated and resolved by `resolveReconnectPolicy`. */
+  reconnect: ResolvedReconnectPolicy
   handlers: LogOptions
   basePath: string
   authService: AuthManager
@@ -71,6 +75,14 @@ type AttemptResult =
       timedOut: boolean
       event?: WebSocketEventMap['error']
     }
+
+/**
+ * Outcome of {@link LogStream.runReconnectLoop}: `'opened'` once a socket is
+ * genuinely open again, `'failed'` when the policy or the budget gives up,
+ * `'aborted'` when the stream went stale (closed, destroyed, or superseded)
+ * partway through — nothing to report either way.
+ */
+type ReconnectLoopOutcome = { outcome: 'opened' } | { outcome: 'aborted' } | { outcome: 'failed'; error: WsError }
 
 const DEFAULT_TUNING: LogStreamTuning = {
   connectTimeoutMs: WS_CONNECT_TIMEOUT_MS,
@@ -111,6 +123,8 @@ export class LogStream {
   private readonly lifecycle: Lifecycle
   private readonly onClosed: () => void
   private readonly tuning: LogStreamTuning
+  /** Non-timing parts of the reconnect policy — `tuning` carries the timing overrides instead (see the constructor). */
+  private readonly policy: ResolvedReconnectPolicy
 
   private readonly replay: ReplayFilter
   /** Safe-wrapped `onMessage` — call `emitMessage()` instead, which applies the replay filter first. */
@@ -144,7 +158,12 @@ export class LogStream {
     this.httpsAgent = options.httpsAgent
     this.lifecycle = options.lifecycle
     this.onClosed = options.onClosed
-    this.tuning = { ...DEFAULT_TUNING, ...options.tuning }
+    // `tuning` layering: module defaults < the policy's explicit timing
+    // overrides < the internal test-only seam, which must always win so
+    // logs-stream.server.test.ts's `tune(instance, {...})` isn't silently
+    // clobbered by a fully-populated policy.
+    this.tuning = { ...DEFAULT_TUNING, ...reconnectPolicyToTuning(options.reconnect), ...options.tuning }
+    this.policy = options.reconnect
     this.replay = createReplayFilter(options.replay)
 
     this.deliverMessage = safeCallback(options.handlers.onMessage, error =>
@@ -179,8 +198,15 @@ export class LogStream {
    * not merely constructed — so a misconfigured `baseUrl` or a panel that's
    * down fails loudly here instead of handing back a dead stream.
    *
+   * With `reconnect.initial`, a failed first connect is retried through the
+   * same policy-gated loop a post-open drop uses, instead of rejecting
+   * immediately — but a failure still only ever rejects this promise, never
+   * `onError`/`onClose`, since the stream never reached `open` (ADR-0016:
+   * reported exactly once).
+   *
    * @throws {WsError} When the handshake fails twice, the second time with a
-   * freshly issued token.
+   * freshly issued token — or, with `reconnect.initial`, when the retry loop
+   * itself gives up.
    * @throws {AuthError} When authenticating for the first attempt fails.
    */
   async open(): Promise<void> {
@@ -189,11 +215,33 @@ export class LogStream {
     try {
       await this.connectPhase(1)
     } catch (error) {
-      // A stream that never opened owns no resources worth keeping, and its
-      // caller is getting a rejection rather than a close handle — so it
-      // untracks itself here instead of relying on the caller to do it.
-      this.close()
-      throw error
+      if (!this.policy.initial || this.isStale(this.generation)) {
+        // A stream that never opened owns no resources worth keeping, and its
+        // caller is getting a rejection rather than a close handle — so it
+        // untracks itself here instead of relying on the caller to do it.
+        this.close()
+        throw error
+      }
+
+      this.dropStartedAt = this.tuning.now()
+      // connectPhase() only ever throws a WsError (see its @throws contract).
+      this.lastError = error as WsError
+      this.budgetDeadline = this.tuning.now() + this.tuning.reconnectBudgetMs
+
+      const outcome = await this.runReconnectLoop(this.budgetDeadline)
+
+      if (outcome.outcome === 'failed') {
+        this.logger.error(
+          `WebSocket stream never opened (${this.endpoint}): ${outcome.error.message}`,
+          outcome.error,
+          'LogsStream'
+        )
+        this.shutdown()
+        throw outcome.error
+      }
+      // 'opened' or 'aborted' fall through to the checks below, exactly like
+      // a direct first-attempt success — an 'aborted' loop is caught by the
+      // isStale() check right after.
     }
 
     // Destroyed while the handshake was in flight: the caller is holding a
@@ -491,53 +539,8 @@ export class LogStream {
     // for the same reason, so backoff keeps growing across a flap.
     this.budgetDeadline ??= this.tuning.now() + this.tuning.reconnectBudgetMs
 
-    void this.runReconnectLoop(this.budgetDeadline)
-  }
-
-  /**
-   * Retries with exponential backoff + jitter until the stream opens again,
-   * the budget runs out, or the panel positively refuses a freshly
-   * authenticated connection.
-   */
-  private async runReconnectLoop(budgetDeadline: number): Promise<void> {
-    for (;;) {
-      const generation = this.generation
-      this.reconnectAttempt++
-
-      const delay = computeBackoff(this.reconnectAttempt, {
-        baseMs: this.tuning.backoffBaseMs,
-        maxMs: this.tuning.backoffMaxMs,
-        jitter: true,
-      })
-
-      this.logger.debug(
-        `Reconnecting to ${this.endpoint} in ${Math.round(delay)}ms (attempt ${this.reconnectAttempt})`,
-        'LogsStream'
-      )
-      await this.tuning.sleep(delay)
-      if (this.isStale(generation)) return
-
-      if (this.tuning.now() >= budgetDeadline) {
-        // `lastError` is always set here: this loop only ever runs after
-        // `handleDrop()` set it, and it's the closest thing to "why" the
-        // budget ran out — reused as the best-effort event to report.
-        const lastError = this.lastError!
-        this.terminate(
-          new WsError(ERROR_CODES.WS_RETRIES_EXHAUSTED, {
-            phase: 'connection',
-            attempt: this.reconnectAttempt,
-            url: this.currentUrl,
-            closeCode: lastError.closeCode,
-            event: lastError.details?.event,
-          })
-        )
-        return
-      }
-
-      try {
-        await this.connectPhase(this.reconnectAttempt)
-        if (this.isStale(this.generation)) return
-
+    void this.runReconnectLoop(this.budgetDeadline).then(outcome => {
+      if (outcome.outcome === 'opened') {
         this.markOpen()
         this.logger.info(`WebSocket connection re-established: ${this.endpoint}`, 'LogsStream')
         this.emitOpen()
@@ -545,9 +548,80 @@ export class LogStream {
         // `handleDrop()`, which sets it right before the first iteration.
         this.emitReconnect({ attempt: this.reconnectAttempt, downtimeMs: this.tuning.now() - this.dropStartedAt! })
         this.armStableTimer()
-        return
+      } else if (outcome.outcome === 'failed') {
+        this.terminate(outcome.error)
+      }
+      // 'aborted': the loop already found the stream stale (closed,
+      // destroyed, or superseded) — nothing to report, same as before.
+    })
+  }
+
+  /**
+   * Retries with exponential backoff + jitter — gated by the reconnect
+   * policy on every attempt — until the stream opens again, the policy
+   * declines to continue, the budget runs out, or the panel positively
+   * refuses a freshly authenticated connection.
+   *
+   * Owns no state transitions or emits itself: it hands its outcome back to
+   * the caller, since a post-open drop (`handleDrop`) and a `reconnect.initial`
+   * retry of the very first connect (`open`) each have to report it
+   * differently (ADR-0016: a failure before the stream ever opened rejects
+   * `connect*()` directly, never through `onError`/`onClose`).
+   */
+  private async runReconnectLoop(budgetDeadline: number): Promise<ReconnectLoopOutcome> {
+    for (;;) {
+      const generation = this.generation
+      const attempt = this.reconnectAttempt + 1
+
+      const baseDelayMs = computeBackoff(attempt, {
+        baseMs: this.tuning.backoffBaseMs,
+        maxMs: this.tuning.backoffMaxMs,
+        jitter: true,
+      })
+      // `dropStartedAt` and `lastError` are always set here: this loop only
+      // ever runs after `handleDrop()` or `open()`'s `reconnect.initial`
+      // branch set them first.
+      const verdict = decideReconnect({
+        policy: this.policy,
+        attempt,
+        elapsedMs: this.tuning.now() - this.dropStartedAt!,
+        baseDelayMs,
+        error: this.lastError!,
+      })
+
+      if (!verdict.retry) return { outcome: 'failed', error: this.lastError! }
+
+      this.reconnectAttempt = attempt
+      this.logger.debug(
+        `Reconnecting to ${this.endpoint} in ${Math.round(verdict.delayMs)}ms (attempt ${attempt})`,
+        'LogsStream'
+      )
+      await this.tuning.sleep(verdict.delayMs)
+      if (this.isStale(generation)) return { outcome: 'aborted' }
+
+      if (this.tuning.now() >= budgetDeadline) {
+        // Reused as the best-effort event to report — nothing new happened,
+        // the budget simply ran out.
+        const lastError = this.lastError!
+        return {
+          outcome: 'failed',
+          error: new WsError(ERROR_CODES.WS_RETRIES_EXHAUSTED, {
+            phase: 'connection',
+            attempt: this.reconnectAttempt,
+            url: this.currentUrl,
+            closeCode: lastError.closeCode,
+            event: lastError.details?.event,
+          }),
+        }
+      }
+
+      try {
+        await this.connectPhase(this.reconnectAttempt)
+        if (this.isStale(this.generation)) return { outcome: 'aborted' }
+
+        return { outcome: 'opened' }
       } catch (error) {
-        if (this.isStale(this.generation)) return
+        if (this.isStale(this.generation)) return { outcome: 'aborted' }
 
         // Only a status the transport actually reported proves the panel
         // refused us; retrying that with a token we just refreshed is
@@ -561,8 +635,7 @@ export class LogStream {
             error,
             'LogsStream'
           )
-          this.terminate(error)
-          return
+          return { outcome: 'failed', error }
         }
       }
     }

--- a/packages/sdk/src/core/ws/log-stream.ts
+++ b/packages/sdk/src/core/ws/log-stream.ts
@@ -7,13 +7,13 @@ import {
   WS_STABLE_AFTER_MS,
 } from '@/config'
 import { AuthManager } from '@/core/auth'
-import { ERROR_CODES, type FormatCode, SdkDestroyedError, WsError } from '@/core/errors'
+import { ERROR_CODES, SdkDestroyedError, WsError } from '@/core/errors'
 import { Logger } from '@/core/logger'
 
 import { computeBackoff } from '../backoff'
 import { Lifecycle } from '../lifecycle'
 import { BaseWebSocketClient, WebSocketClient } from './client'
-import type { LogOptions } from './logs-stream'
+import type { LogOptions, WsCloseInfo, WsReconnectInfo } from './logs-stream'
 import { configurationUrlWs } from './utils'
 import { closeQuietly } from './utils/close-quietly'
 import { extractWsHandshakeStatus, getWsErrorMessage } from './utils/ws-error'
@@ -110,18 +110,25 @@ export class LogStream {
   private readonly tuning: LogStreamTuning
 
   private readonly emitMessage: (data: AnyType) => void
-  private readonly emitError: (event: WebSocketEventMap['error']) => void
+  private readonly emitError: (error: WsError) => void
+  private readonly emitOpen: () => void
+  private readonly emitReconnect: (info: WsReconnectInfo) => void
+  private readonly emitClose: (info: WsCloseInfo) => void
 
   private _state: LogStreamState = 'connecting'
+  /** Set once the stream first reaches `open` — gates whether a self-inflicted end reports through `onError`/`onClose` at all (ADR-0016: a failure before that point is reported through the `connect*()` rejection alone). */
+  private everOpened = false
   /** Bumped for every new socket, so a superseded socket's late events are ignored. */
   private generation = 0
   private client?: BaseWebSocketClient
   private currentUrl = ''
   private reconnectAttempt = 0
   private budgetDeadline?: number
+  /** When the most recent drop happened — set by `handleDrop()`, read by a successful reconnect to compute `WsReconnectInfo.downtimeMs`. */
+  private dropStartedAt?: number
   private readonly timers = new Set<ReturnType<typeof setTimeout>>()
-  /** Kept so a terminal `onError` can forward a real event — `LogOptions.onError` still takes one (issue #89 changes that). */
-  private lastDropEvent?: WebSocketEventMap['error']
+  /** The most recent transport drop, wrapped as a `WsError` — reused as the best-effort event when the reconnect budget expires with nothing new to report. */
+  private lastError?: WsError
 
   constructor(options: LogStreamOptions) {
     this.endpoint = options.endpoint
@@ -139,6 +146,15 @@ export class LogStream {
     )
     this.emitError = safeCallback(options.handlers.onError, error =>
       this.logger.error(`onError callback threw (${this.endpoint})`, error, 'LogsStream')
+    )
+    this.emitOpen = safeCallback<void>(options.handlers.onOpen, error =>
+      this.logger.error(`onOpen callback threw (${this.endpoint})`, error, 'LogsStream')
+    )
+    this.emitReconnect = safeCallback(options.handlers.onReconnect, error =>
+      this.logger.error(`onReconnect callback threw (${this.endpoint})`, error, 'LogsStream')
+    )
+    this.emitClose = safeCallback(options.handlers.onClose, error =>
+      this.logger.error(`onClose callback threw (${this.endpoint})`, error, 'LogsStream')
     )
   }
 
@@ -181,17 +197,35 @@ export class LogStream {
     // is exactly what they asked for.
     if (this.isStale(this.generation)) return
 
-    this._state = 'open'
+    this.markOpen()
     this.logger.info(`WebSocket connection established: ${this.endpoint}`, 'LogsStream')
+    this.emitOpen()
+  }
+
+  /** Transitions into `open`, once and for all — first connect or a successful reconnect. */
+  private markOpen(): void {
+    this._state = 'open'
+    this.everOpened = true
   }
 
   /**
    * Terminal and idempotent: stops any in-flight reconnect at its next
    * checkpoint, closes the current socket, and drops every timer.
+   *
+   * Reports through `onClose({ byCaller: true })` — but only if the stream
+   * ever reached `open`; a first connect that never got there is reported
+   * through the `connect*()` rejection alone (ADR-0016).
    */
   close(): void {
     if (this._state === 'closed') return
 
+    const everOpened = this.everOpened
+    this.shutdown()
+    if (everOpened) this.emitClose({ byCaller: true })
+  }
+
+  /** State transition shared by `close()` and `terminate()`: stop, drop every timer and the socket, untrack. */
+  private shutdown(): void {
     this.logger.debug(`Closing WebSocket connection: ${this.endpoint}`, 'LogsStream')
     this._state = 'closed'
     // Bumped so an in-flight attempt's own listeners and post-await checks
@@ -427,7 +461,14 @@ export class LogStream {
     if (this.isStale(generation)) return
 
     this._state = 'reconnecting'
-    this.lastDropEvent = event
+    this.dropStartedAt = this.tuning.now()
+    this.lastError = new WsError(ERROR_CODES.WS_CONNECTION_LOST, {
+      phase: 'connection',
+      attempt: this.reconnectAttempt + 1,
+      url: this.currentUrl,
+      closeCode: (event as AnyType)?.code,
+      event,
+    })
 
     // An existing deadline is kept deliberately: a stream that flaps — opens,
     // drops, opens, drops — must not hand itself a fresh budget on every
@@ -463,7 +504,19 @@ export class LogStream {
       if (this.isStale(generation)) return
 
       if (this.tuning.now() >= budgetDeadline) {
-        this.terminate(ERROR_CODES.WS_RETRIES_EXHAUSTED)
+        // `lastError` is always set here: this loop only ever runs after
+        // `handleDrop()` set it, and it's the closest thing to "why" the
+        // budget ran out — reused as the best-effort event to report.
+        const lastError = this.lastError!
+        this.terminate(
+          new WsError(ERROR_CODES.WS_RETRIES_EXHAUSTED, {
+            phase: 'connection',
+            attempt: this.reconnectAttempt,
+            url: this.currentUrl,
+            closeCode: lastError.closeCode,
+            event: lastError.details?.event,
+          })
+        )
         return
       }
 
@@ -471,8 +524,12 @@ export class LogStream {
         await this.connectPhase(this.reconnectAttempt)
         if (this.isStale(this.generation)) return
 
-        this._state = 'open'
+        this.markOpen()
         this.logger.info(`WebSocket connection re-established: ${this.endpoint}`, 'LogsStream')
+        this.emitOpen()
+        // `dropStartedAt` is always set here: the only path into this loop is
+        // `handleDrop()`, which sets it right before the first iteration.
+        this.emitReconnect({ attempt: this.reconnectAttempt, downtimeMs: this.tuning.now() - this.dropStartedAt! })
         this.armStableTimer()
         return
       } catch (error) {
@@ -490,7 +547,7 @@ export class LogStream {
             error,
             'LogsStream'
           )
-          this.terminate(ERROR_CODES.WS_AUTH_FAILED, error.details?.event as WebSocketEventMap['error'])
+          this.terminate(error)
           return
         }
       }
@@ -508,12 +565,18 @@ export class LogStream {
     }, this.tuning.stableAfterMs)
   }
 
-  /** Ends the stream for good and tells the consumer, since their `connect*()` promise resolved long ago. */
-  private terminate(code: FormatCode, event?: WebSocketEventMap['error']): void {
-    this.logger.error(`WebSocket stream terminated (${this.endpoint}): ${code.message}`, null, 'LogsStream')
+  /**
+   * Ends the stream for good and tells the consumer, since their
+   * `connect*()` promise resolved long ago: `onError(error)` followed by
+   * `onClose({ byCaller: false })`. Only ever reached after the stream has
+   * opened at least once (both call sites are downstream of `handleDrop()`),
+   * so — unlike `close()` — this never needs to check `everOpened`.
+   */
+  private terminate(error: WsError): void {
+    this.logger.error(`WebSocket stream terminated (${this.endpoint}): ${error.message}`, error, 'LogsStream')
 
-    const failure = event ?? this.lastDropEvent ?? ({ type: 'error', message: code.message } as AnyType)
-    this.close()
-    this.emitError(failure)
+    this.shutdown()
+    this.emitError(error)
+    this.emitClose({ code: error.closeCode, byCaller: false })
   }
 }

--- a/packages/sdk/src/core/ws/log-stream.ts
+++ b/packages/sdk/src/core/ws/log-stream.ts
@@ -16,6 +16,7 @@ import { BaseWebSocketClient, WebSocketClient } from './client'
 import type { LogOptions, WsCloseInfo, WsReconnectInfo } from './logs-stream'
 import { configurationUrlWs } from './utils'
 import { closeQuietly } from './utils/close-quietly'
+import { createReplayFilter, type ReplayFilter, type ReplayMode } from './utils/replay'
 import { extractWsHandshakeStatus, getWsErrorMessage } from './utils/ws-error'
 
 /**
@@ -41,6 +42,8 @@ export interface LogStreamOptions {
   endpoint: string
   /** Already validated against the panel's own range by `resolveLogInterval`. */
   interval: number
+  /** Already validated by `resolveReplayMode`. */
+  replay: ReplayMode
   handlers: LogOptions
   basePath: string
   authService: AuthManager
@@ -109,7 +112,9 @@ export class LogStream {
   private readonly onClosed: () => void
   private readonly tuning: LogStreamTuning
 
-  private readonly emitMessage: (data: AnyType) => void
+  private readonly replay: ReplayFilter
+  /** Safe-wrapped `onMessage` — call `emitMessage()` instead, which applies the replay filter first. */
+  private readonly deliverMessage: (data: AnyType) => void
   private readonly emitError: (error: WsError) => void
   private readonly emitOpen: () => void
   private readonly emitReconnect: (info: WsReconnectInfo) => void
@@ -140,8 +145,9 @@ export class LogStream {
     this.lifecycle = options.lifecycle
     this.onClosed = options.onClosed
     this.tuning = { ...DEFAULT_TUNING, ...options.tuning }
+    this.replay = createReplayFilter(options.replay)
 
-    this.emitMessage = safeCallback(options.handlers.onMessage, error =>
+    this.deliverMessage = safeCallback(options.handlers.onMessage, error =>
       this.logger.error(`onMessage callback threw (${this.endpoint})`, error, 'LogsStream')
     )
     this.emitError = safeCallback(options.handlers.onError, error =>
@@ -160,6 +166,12 @@ export class LogStream {
 
   get state(): LogStreamState {
     return this._state
+  }
+
+  /** Applies the replay filter, then delivers to `onMessage` if it isn't a suppressed replay of an already-seen line. */
+  private emitMessage(data: AnyType): void {
+    const decision = this.replay.accept(data)
+    if (decision.deliver) this.deliverMessage(decision.data as AnyType)
   }
 
   /**
@@ -462,6 +474,8 @@ export class LogStream {
 
     this._state = 'reconnecting'
     this.dropStartedAt = this.tuning.now()
+    // Armed only here — never on the first connect, where the ring is empty anyway.
+    this.replay.arm()
     this.lastError = new WsError(ERROR_CODES.WS_CONNECTION_LOST, {
       phase: 'connection',
       attempt: this.reconnectAttempt + 1,

--- a/packages/sdk/src/core/ws/log-stream.ts
+++ b/packages/sdk/src/core/ws/log-stream.ts
@@ -13,6 +13,7 @@ import { Logger } from '@/core/logger'
 import { computeBackoff } from '../backoff'
 import { Lifecycle } from '../lifecycle'
 import { BaseWebSocketClient, WebSocketClient } from './client'
+import { selectWsTransportKind, transportSupportsHeaders } from './client/select-transport'
 import type { LogOptions, WsCloseInfo, WsReconnectInfo } from './logs-stream'
 import { configurationUrlWs } from './utils'
 import { closeQuietly } from './utils/close-quietly'
@@ -395,11 +396,16 @@ export class LogStream {
     }
   }
 
-  private buildWsUrl(): string {
+  /**
+   * `token` goes into the URL query only when the transport can't carry it
+   * as a header instead (see `attemptOnce` — decided before this is called,
+   * never the other way around).
+   */
+  private buildWsUrl(token: string | undefined): string {
     const wsUrl = configurationUrlWs({
       basePath: this.basePath,
       endpoint: this.endpoint,
-      token: this.authService.accessToken,
+      token,
       interval: this.interval,
     })
 
@@ -421,13 +427,22 @@ export class LogStream {
     await this.ensureAuthenticated()
     if (this.isStale(generation)) return { outcome: 'aborted' }
 
-    const url = this.buildWsUrl()
+    // The transport decides first — a URL built before knowing it could put
+    // the token in the query on a client that was about to send it as a
+    // header instead (or vice versa), and the socket would carry neither.
+    const kind = selectWsTransportKind({ agent: this.httpsAgent })
+    const useHeader = transportSupportsHeaders(kind)
+    const token = this.authService.accessToken
+    const url = this.buildWsUrl(useHeader ? undefined : token)
     this.currentUrl = url
 
     // Resolved (not connected) so every listener is attached before `init()`
     // constructs the socket — a connect that fails before the first microtask
     // still reaches them instead of nobody (issue #86).
-    const client = WebSocketClient.resolve(url, undefined, { agent: this.httpsAgent })
+    const client = WebSocketClient.resolve(url, undefined, {
+      agent: this.httpsAgent,
+      headers: useHeader ? { Authorization: `Bearer ${token}` } : undefined,
+    })
     this.client = client
 
     this.logger.debug(`Establishing WebSocket connection to: ${this.endpoint} (attempt ${attempt})`, 'LogsStream')

--- a/packages/sdk/src/core/ws/logs-stream.server.test.ts
+++ b/packages/sdk/src/core/ws/logs-stream.server.test.ts
@@ -69,7 +69,16 @@ describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName =
     const [handshake] = await panel.waitForHandshakes(1)
     expect(handshake!.pathname).toBe('/api/core/logs')
     expect(handshake!.interval).toBe('7')
-    expect(handshake!.token).toBe('mock-access-token')
+    // Only the ws-package transport can send a header — there, the token
+    // moves out of the URL entirely; the native transport has no such
+    // option, so it always carries it in the query string (issue #89).
+    if (transportName === 'ws-package') {
+      expect(handshake!.token).toBeNull()
+      expect(handshake!.headers.authorization).toBe('Bearer mock-access-token')
+    } else {
+      expect(handshake!.token).toBe('mock-access-token')
+      expect(handshake!.headers.authorization).toBeUndefined()
+    }
     expect(panel.logins).toEqual([{ username: 'admin', password: 'secret' }])
   })
 
@@ -112,7 +121,12 @@ describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName =
     await instance.logs.connectByCore({ onMessage: () => {} })
 
     const handshakes = await panel.waitForHandshakes(2)
-    expect(handshakes[1]?.token).toBe('second-token')
+    if (transportName === 'ws-package') {
+      expect(handshakes[1]?.token).toBeNull()
+      expect(handshakes[1]?.headers.authorization).toBe('Bearer second-token')
+    } else {
+      expect(handshakes[1]?.token).toBe('second-token')
+    }
   })
 
   it('rejects an out-of-range interval before opening a socket (issue #87)', async () => {
@@ -178,8 +192,14 @@ describe.each(WS_TRANSPORTS)('LogsStream over the %s transport', transportName =
 
     expect(isWsError(error) && error.phase).toBe('handshake')
     expect(isWsError(error) && error.attempt).toBe(2)
-    expect(isWsError(error) && error.url).toContain('token=REDACTED')
+    // Transport-agnostic invariant: the token is never in the URL, whether
+    // that's because it was redacted (native — it was there, in the query)
+    // or because it was never put there in the first place (ws-package — it
+    // went out as a header instead).
     expect(isWsError(error) && error.url).not.toContain('mock-access-token')
+    if (transportName === 'native') {
+      expect(isWsError(error) && error.url).toContain('token=REDACTED')
+    }
   })
 
   // ─── Reconnect after a transport drop (issue #88's headline case) ──────────

--- a/packages/sdk/src/core/ws/logs-stream.ts
+++ b/packages/sdk/src/core/ws/logs-stream.ts
@@ -1,5 +1,6 @@
 import { type HttpAgentLike, isBrowser } from '@/common'
 import { AuthManager } from '@/core/auth'
+import { WsError } from '@/core/errors'
 import { Logger } from '@/core/logger'
 
 import { Lifecycle } from '../lifecycle'
@@ -10,6 +11,22 @@ import { createStreamHandle, type StreamHandle } from './utils/stream-handle'
 /** Handle returned by `connect*()`: callable (closes the stream), plus an explicit `close()` and a live `state`. */
 export type LogStreamHandle = StreamHandle<LogStreamState>
 
+/** Passed to `LogOptions.onClose` once, when the logical stream ends for good. */
+export interface WsCloseInfo {
+  /** The WebSocket close code, when one is known — absent for a caller-initiated close. */
+  code?: number
+  /** `true` when the consumer ended the stream (the handle, `close()`, or `sdk.destroy()`); `false` when it died on its own. */
+  byCaller: boolean
+}
+
+/** Passed to `LogOptions.onReconnect` when a dropped stream successfully reopens. */
+export interface WsReconnectInfo {
+  /** 1-based reconnect attempt that succeeded. Carries over across a flapping connection. */
+  attempt: number
+  /** Time (ms) since the most recent drop — not the start of a longer flapping sequence. */
+  downtimeMs: number
+}
+
 /**
  * Options for configuring a WebSocket log stream.
  */
@@ -18,8 +35,14 @@ export interface LogOptions {
   interval?: number
   /** Callback triggered when a message is received */
   onMessage: (data: WebSocketEventMap['message']['data']) => void
-  /** Callback triggered when a connection error occurs */
-  onError?: (data: WebSocketEventMap['error']) => void
+  /** Called once the stream ends for good, with a typed error — never a raw transport event. */
+  onError?: (error: WsError) => void
+  /** Called every time the stream reaches `open` — the first connect and each successful reconnect. */
+  onOpen?: () => void
+  /** Called when a dropped stream successfully reopens. */
+  onReconnect?: (info: WsReconnectInfo) => void
+  /** Called once, when the stream ends for good — only if it ever reached `open`. */
+  onClose?: (info: WsCloseInfo) => void
 }
 
 /**

--- a/packages/sdk/src/core/ws/logs-stream.ts
+++ b/packages/sdk/src/core/ws/logs-stream.ts
@@ -3,9 +3,12 @@ import { AuthManager } from '@/core/auth'
 import { Logger } from '@/core/logger'
 
 import { Lifecycle } from '../lifecycle'
-import { LogStream, type LogStreamTuning } from './log-stream'
-import type { HandleCloseConnection } from './utils/connection-handle.types'
+import { LogStream, type LogStreamState, type LogStreamTuning } from './log-stream'
 import { resolveLogInterval } from './utils/log-interval'
+import { createStreamHandle, type StreamHandle } from './utils/stream-handle'
+
+/** Handle returned by `connect*()`: callable (closes the stream), plus an explicit `close()` and a live `state`. */
+export type LogStreamHandle = StreamHandle<LogStreamState>
 
 /**
  * Options for configuring a WebSocket log stream.
@@ -90,7 +93,7 @@ export class LogsStream {
    * Resolves only once the socket is genuinely open, so a failed first
    * connect rejects instead of handing back a handle to a dead stream.
    */
-  private async connect(endpoint: string, options: LogOptions): Promise<HandleCloseConnection> {
+  private async connect(endpoint: string, options: LogOptions): Promise<LogStreamHandle> {
     this.lifecycle.assertActive(`logs.connect(${endpoint})`)
 
     const interval = resolveLogInterval(options.interval)
@@ -111,13 +114,14 @@ export class LogsStream {
 
     await stream.open()
 
-    return () => stream.close()
+    return createStreamHandle(stream)
   }
 
   /**
    * Connects to the core logs (`/api/core/logs`).
    * @param options Connection options (callbacks, interval).
-   * @returns A function to close the WebSocket connection.
+   * @returns A {@link LogStreamHandle} — callable to close the stream (source-compatible with the
+   * bare close function this used to return), plus an explicit `close()` and a live `state`.
    * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    * @throws {WsOptionsError} If `interval` is outside the range the panel accepts.
    * @throws {WsError} If the connection cannot be established.
@@ -131,7 +135,8 @@ export class LogsStream {
    * Connects to logs of a specific node (`/api/node/{nodeId}/logs`).
    * @param nodeId The ID of the node whose logs should be accessed.
    * @param options Connection options (callbacks, interval).
-   * @returns A function to close the WebSocket connection.
+   * @returns A {@link LogStreamHandle} — callable to close the stream (source-compatible with the
+   * bare close function this used to return), plus an explicit `close()` and a live `state`.
    * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
    * @throws {WsOptionsError} If `interval` is outside the range the panel accepts.
    * @throws {WsError} If the connection cannot be established.

--- a/packages/sdk/src/core/ws/logs-stream.ts
+++ b/packages/sdk/src/core/ws/logs-stream.ts
@@ -6,7 +6,10 @@ import { Logger } from '@/core/logger'
 import { Lifecycle } from '../lifecycle'
 import { LogStream, type LogStreamState, type LogStreamTuning } from './log-stream'
 import { resolveLogInterval } from './utils/log-interval'
+import { type ReplayMode, resolveReplayMode } from './utils/replay'
 import { createStreamHandle, type StreamHandle } from './utils/stream-handle'
+
+export type { ReplayMode }
 
 /** Handle returned by `connect*()`: callable (closes the stream), plus an explicit `close()` and a live `state`. */
 export type LogStreamHandle = StreamHandle<LogStreamState>
@@ -43,6 +46,17 @@ export interface LogOptions {
   onReconnect?: (info: WsReconnectInfo) => void
   /** Called once, when the stream ends for good — only if it ever reached `open`. */
   onClose?: (info: WsCloseInfo) => void
+  /**
+   * How to handle log lines the panel re-delivers after a reconnect — it
+   * seeds every new connection from a shared buffer of its last ~100 lines
+   * (docs/marzban-quirks.md), with no cursor to resume from instead.
+   *
+   * - `'dedup'` (default) — suppress lines already delivered before the drop.
+   * - `'all'` — deliver everything, duplicates included.
+   * - `'skip'` — drop every replayed message outright, until the first one
+   *   that carries no previously-delivered line.
+   */
+  replay?: ReplayMode
 }
 
 /**
@@ -120,10 +134,12 @@ export class LogsStream {
     this.lifecycle.assertActive(`logs.connect(${endpoint})`)
 
     const interval = resolveLogInterval(options.interval)
+    const replay = resolveReplayMode(options.replay)
 
     const stream = new LogStream({
       endpoint,
       interval,
+      replay,
       handlers: options,
       basePath: this.basePath,
       authService: this.authService,
@@ -146,7 +162,7 @@ export class LogsStream {
    * @returns A {@link LogStreamHandle} — callable to close the stream (source-compatible with the
    * bare close function this used to return), plus an explicit `close()` and a live `state`.
    * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
-   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts.
+   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts, or `replay` is invalid.
    * @throws {WsError} If the connection cannot be established.
    */
   async connectByCore(options: LogOptions) {
@@ -161,7 +177,7 @@ export class LogsStream {
    * @returns A {@link LogStreamHandle} — callable to close the stream (source-compatible with the
    * bare close function this used to return), plus an explicit `close()` and a live `state`.
    * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
-   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts.
+   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts, or `replay` is invalid.
    * @throws {WsError} If the connection cannot be established.
    */
   async connectByNode(nodeId: number | string, options: LogOptions) {

--- a/packages/sdk/src/core/ws/logs-stream.ts
+++ b/packages/sdk/src/core/ws/logs-stream.ts
@@ -6,10 +6,16 @@ import { Logger } from '@/core/logger'
 import { Lifecycle } from '../lifecycle'
 import { LogStream, type LogStreamState, type LogStreamTuning } from './log-stream'
 import { resolveLogInterval } from './utils/log-interval'
+import {
+  type ReconnectOption,
+  type ReconnectOptions,
+  resolveReconnectPolicy,
+  type ShouldReconnectContext,
+} from './utils/reconnect-policy'
 import { type ReplayMode, resolveReplayMode } from './utils/replay'
 import { createStreamHandle, type StreamHandle } from './utils/stream-handle'
 
-export type { ReplayMode }
+export type { ReconnectOption, ReconnectOptions, ReplayMode, ShouldReconnectContext }
 
 /** Handle returned by `connect*()`: callable (closes the stream), plus an explicit `close()` and a live `state`. */
 export type LogStreamHandle = StreamHandle<LogStreamState>
@@ -57,6 +63,12 @@ export interface LogOptions {
    *   that carries no previously-delivered line.
    */
   replay?: ReplayMode
+  /**
+   * Overrides the SDK-wide {@link LogsStreamOptions.reconnect} default for
+   * this stream. `false` disables reconnecting entirely; `true` or an
+   * options object enables it, with any explicit overrides.
+   */
+  reconnect?: ReconnectOption
 }
 
 /**
@@ -76,6 +88,12 @@ export interface LogsStreamOptions {
   httpsAgent?: HttpAgentLike
   /** Shared SDK-instance terminal-state flag. Defaults to a fresh, always-active one when omitted. */
   lifecycle?: Lifecycle
+  /**
+   * SDK-wide default reconnect policy for every stream opened through this
+   * instance — `LogOptions.reconnect` overrides it per call. Defaults to
+   * enabled, with no explicit timing overrides, when omitted.
+   */
+  reconnect?: ReconnectOption
   /**
    * Overrides for the reconnect policy's timing. Internal — used by this
    * package's own tests to exercise backoff/budget/timeout behavior without
@@ -102,17 +120,27 @@ export class LogsStream {
   private httpsAgent?: HttpAgentLike
   private lifecycle: Lifecycle
   private tuning?: Partial<LogStreamTuning>
+  private defaultReconnect?: ReconnectOption
 
   /**
    * Creates an API instance for handling logs via WebSocket.
    * @param options Configuration for the log stream. See {@link LogsStreamOptions}.
    */
-  constructor({ basePath, authService, logger, httpsAgent, lifecycle = new Lifecycle(), tuning }: LogsStreamOptions) {
+  constructor({
+    basePath,
+    authService,
+    logger,
+    httpsAgent,
+    lifecycle = new Lifecycle(),
+    reconnect,
+    tuning,
+  }: LogsStreamOptions) {
     this.basePath = basePath
     this.authService = authService
     this.logger = logger
     this.httpsAgent = httpsAgent
     this.lifecycle = lifecycle
+    this.defaultReconnect = reconnect
     this.tuning = tuning
     this.logger.debug('LogsStream initialized', 'LogsStream')
 
@@ -135,11 +163,15 @@ export class LogsStream {
 
     const interval = resolveLogInterval(options.interval)
     const replay = resolveReplayMode(options.replay)
+    // Per-call `reconnect` fully replaces the SDK-wide default when given,
+    // same as `interval`/`replay` — no field-by-field merging between the two.
+    const reconnect = resolveReconnectPolicy(options.reconnect ?? this.defaultReconnect)
 
     const stream = new LogStream({
       endpoint,
       interval,
       replay,
+      reconnect,
       handlers: options,
       basePath: this.basePath,
       authService: this.authService,
@@ -162,7 +194,7 @@ export class LogsStream {
    * @returns A {@link LogStreamHandle} — callable to close the stream (source-compatible with the
    * bare close function this used to return), plus an explicit `close()` and a live `state`.
    * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
-   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts, or `replay` is invalid.
+   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts, or `replay`/`reconnect` is invalid.
    * @throws {WsError} If the connection cannot be established.
    */
   async connectByCore(options: LogOptions) {
@@ -177,7 +209,7 @@ export class LogsStream {
    * @returns A {@link LogStreamHandle} — callable to close the stream (source-compatible with the
    * bare close function this used to return), plus an explicit `close()` and a live `state`.
    * @throws {SdkDestroyedError} If the owning SDK has been destroyed.
-   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts, or `replay` is invalid.
+   * @throws {WsOptionsError} If `interval` is outside the range the panel accepts, or `replay`/`reconnect` is invalid.
    * @throws {WsError} If the connection cannot be established.
    */
   async connectByNode(nodeId: number | string, options: LogOptions) {

--- a/packages/sdk/src/core/ws/utils/configuration-url-ws.test.ts
+++ b/packages/sdk/src/core/ws/utils/configuration-url-ws.test.ts
@@ -67,6 +67,12 @@ describe('configurationUrlWs', () => {
       const url = new URL(result)
       expect(url.searchParams.get('token')).toBe('abc123')
     })
+
+    it('omits the token query param entirely when token is undefined', () => {
+      const result = configurationUrlWs({ ...base, token: undefined })
+      const url = new URL(result)
+      expect(url.searchParams.has('token')).toBe(false)
+    })
   })
 
   describe('host preservation', () => {

--- a/packages/sdk/src/core/ws/utils/configuration-url-ws.ts
+++ b/packages/sdk/src/core/ws/utils/configuration-url-ws.ts
@@ -1,7 +1,12 @@
 interface Options {
   basePath: string
   endpoint: string
-  token: string
+  /**
+   * Omit when the token is going out as an `Authorization` header instead
+   * (the `ws`-package transport) — the native transport has no such option,
+   * so it always has to carry the token here.
+   */
+  token?: string
   interval: string | number
 }
 
@@ -17,7 +22,7 @@ export const configurationUrlWs = ({ basePath, endpoint, interval, token }: Opti
   const suffix = endpoint.startsWith('/') ? endpoint : `/${endpoint}`
   url.pathname = `${basePrefix}${suffix}`
   url.searchParams.set('interval', interval.toString())
-  url.searchParams.set('token', token)
+  if (token !== undefined) url.searchParams.set('token', token)
 
   return url.toString()
 }

--- a/packages/sdk/src/core/ws/utils/connection-handle.types.ts
+++ b/packages/sdk/src/core/ws/utils/connection-handle.types.ts
@@ -1,6 +1,0 @@
-export type HandleCloseConnection = () => void
-
-/** Mutable close handle for one logical stream — a retry repoints `.close` at the replacement socket. */
-export interface ConnectionHandle {
-  close: HandleCloseConnection
-}

--- a/packages/sdk/src/core/ws/utils/reconnect-decision.test.ts
+++ b/packages/sdk/src/core/ws/utils/reconnect-decision.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ERROR_CODES, WsError } from '@/core/errors'
+
+import { decideReconnect } from './reconnect-decision'
+import type { ResolvedReconnectPolicy } from './reconnect-policy'
+
+const error = new WsError(ERROR_CODES.WS_CONNECTION_LOST, {
+  phase: 'connection',
+  attempt: 1,
+  url: 'wss://panel.example.com/api/core/logs',
+})
+
+const enabledPolicy: ResolvedReconnectPolicy = { enabled: true, initial: false }
+
+describe('decideReconnect', () => {
+  it('stops when the policy is disabled, without consulting shouldReconnect', () => {
+    const shouldReconnect = vi.fn()
+    const verdict = decideReconnect({
+      policy: { enabled: false, initial: false, shouldReconnect },
+      attempt: 1,
+      elapsedMs: 0,
+      baseDelayMs: 1_000,
+      error,
+    })
+
+    expect(verdict).toEqual({ retry: false })
+    expect(shouldReconnect).not.toHaveBeenCalled()
+  })
+
+  it('retries with the computed backoff when no shouldReconnect is set', () => {
+    const verdict = decideReconnect({ policy: enabledPolicy, attempt: 1, elapsedMs: 0, baseDelayMs: 1_234, error })
+
+    expect(verdict).toEqual({ retry: true, delayMs: 1_234 })
+  })
+
+  it('stops when shouldReconnect returns false', () => {
+    const verdict = decideReconnect({
+      policy: { ...enabledPolicy, shouldReconnect: () => false },
+      attempt: 1,
+      elapsedMs: 0,
+      baseDelayMs: 1_000,
+      error,
+    })
+
+    expect(verdict).toEqual({ retry: false })
+  })
+
+  it('retries with the computed backoff when shouldReconnect returns true', () => {
+    const verdict = decideReconnect({
+      policy: { ...enabledPolicy, shouldReconnect: () => true },
+      attempt: 1,
+      elapsedMs: 0,
+      baseDelayMs: 1_234,
+      error,
+    })
+
+    expect(verdict).toEqual({ retry: true, delayMs: 1_234 })
+  })
+
+  it('retries with the computed backoff when shouldReconnect returns undefined', () => {
+    const verdict = decideReconnect({
+      policy: { ...enabledPolicy, shouldReconnect: () => undefined },
+      attempt: 1,
+      elapsedMs: 0,
+      baseDelayMs: 1_234,
+      error,
+    })
+
+    expect(verdict).toEqual({ retry: true, delayMs: 1_234 })
+  })
+
+  it('overrides the delay when shouldReconnect returns a number', () => {
+    const verdict = decideReconnect({
+      policy: { ...enabledPolicy, shouldReconnect: () => 42 },
+      attempt: 1,
+      elapsedMs: 0,
+      baseDelayMs: 1_234,
+      error,
+    })
+
+    expect(verdict).toEqual({ retry: true, delayMs: 42 })
+  })
+
+  it('passes attempt, elapsedMs and the error through to shouldReconnect', () => {
+    const shouldReconnect = vi.fn().mockReturnValue(true)
+
+    decideReconnect({
+      policy: { ...enabledPolicy, shouldReconnect },
+      attempt: 3,
+      elapsedMs: 5_000,
+      baseDelayMs: 1_000,
+      error,
+    })
+
+    expect(shouldReconnect).toHaveBeenCalledExactlyOnceWith({ attempt: 3, elapsedMs: 5_000, error })
+  })
+})

--- a/packages/sdk/src/core/ws/utils/reconnect-decision.ts
+++ b/packages/sdk/src/core/ws/utils/reconnect-decision.ts
@@ -1,0 +1,44 @@
+import type { WsError } from '@/core/errors'
+
+import type { ResolvedReconnectPolicy } from './reconnect-policy'
+
+export type ReconnectVerdict = { retry: false } | { retry: true; delayMs: number }
+
+export interface DecideReconnectInput {
+  policy: ResolvedReconnectPolicy
+  /** 1-based attempt about to run. */
+  attempt: number
+  /** Time (ms) spent reconnecting since the current drop. */
+  elapsedMs: number
+  /** The backoff delay `shouldReconnect` may accept as-is or override. */
+  baseDelayMs: number
+  /** Why the previous attempt — or the connection itself — failed. */
+  error: WsError
+}
+
+/**
+ * Folds the reconnect policy and the current attempt's circumstances into a
+ * single verdict: stop, or retry after a delay.
+ *
+ * Doesn't know about the reconnect budget — that's a hard cap checked
+ * separately by the caller (`LogStream`), unaffected by `shouldReconnect`.
+ * The escape hatch for "never give up" is `maxElapsedMs: Infinity`, not a
+ * `shouldReconnect` that can outlast the budget.
+ */
+export const decideReconnect = ({
+  policy,
+  attempt,
+  elapsedMs,
+  baseDelayMs,
+  error,
+}: DecideReconnectInput): ReconnectVerdict => {
+  if (!policy.enabled) return { retry: false }
+  if (!policy.shouldReconnect) return { retry: true, delayMs: baseDelayMs }
+
+  const verdict = policy.shouldReconnect({ attempt, elapsedMs, error })
+
+  if (verdict === false) return { retry: false }
+  if (typeof verdict === 'number') return { retry: true, delayMs: verdict }
+  // true or undefined (e.g. an implicit fallthrough return) both accept the computed backoff.
+  return { retry: true, delayMs: baseDelayMs }
+}

--- a/packages/sdk/src/core/ws/utils/reconnect-policy.test.ts
+++ b/packages/sdk/src/core/ws/utils/reconnect-policy.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isWsOptionsError } from '@/core/errors'
+
+import { reconnectPolicyToTuning, resolveReconnectPolicy } from './reconnect-policy'
+
+describe('resolveReconnectPolicy', () => {
+  it('defaults to enabled with no explicit overrides when the option is undefined', () => {
+    expect(resolveReconnectPolicy(undefined)).toEqual({ enabled: true, initial: false })
+  })
+
+  it('treats true the same as the default', () => {
+    expect(resolveReconnectPolicy(true)).toEqual({ enabled: true, initial: false })
+  })
+
+  it('disables reconnecting on false', () => {
+    expect(resolveReconnectPolicy(false)).toEqual({ enabled: false, initial: false })
+  })
+
+  it('resolves every explicit field of an options object', () => {
+    const shouldReconnect = vi.fn()
+
+    expect(
+      resolveReconnectPolicy({
+        initial: true,
+        maxElapsedMs: 60_000,
+        stableAfterMs: 5_000,
+        minDelayMs: 100,
+        maxDelayMs: 10_000,
+        shouldReconnect,
+      })
+    ).toEqual({
+      enabled: true,
+      initial: true,
+      maxElapsedMs: 60_000,
+      stableAfterMs: 5_000,
+      minDelayMs: 100,
+      maxDelayMs: 10_000,
+      shouldReconnect,
+    })
+  })
+
+  it('leaves unset fields undefined rather than defaulting them', () => {
+    const resolved = resolveReconnectPolicy({ minDelayMs: 100 })
+
+    expect(resolved).toEqual({ enabled: true, initial: false, minDelayMs: 100 })
+    expect(resolved.maxElapsedMs).toBeUndefined()
+  })
+
+  it('accepts Infinity for maxElapsedMs (unlimited retries)', () => {
+    expect(resolveReconnectPolicy({ maxElapsedMs: Infinity }).maxElapsedMs).toBe(Infinity)
+  })
+
+  it('throws a WsOptionsError recognized by its guard for an invalid field', () => {
+    expect(() => resolveReconnectPolicy({ minDelayMs: -1 })).toThrow()
+    try {
+      resolveReconnectPolicy({ minDelayMs: -1 })
+      expect.unreachable()
+    } catch (error) {
+      expect(isWsOptionsError(error)).toBe(true)
+    }
+  })
+
+  it('rejects an unknown key', () => {
+    // @ts-expect-error deliberately invalid input
+    expect(() => resolveReconnectPolicy({ maxRetries: 5 })).toThrow()
+  })
+
+  it('rejects a non-function shouldReconnect', () => {
+    // @ts-expect-error deliberately invalid input
+    expect(() => resolveReconnectPolicy({ shouldReconnect: 'nope' })).toThrow()
+  })
+})
+
+describe('reconnectPolicyToTuning', () => {
+  it('maps no fields when the policy has no explicit timing overrides', () => {
+    expect(reconnectPolicyToTuning({ enabled: true, initial: false })).toEqual({})
+  })
+
+  it('maps every explicit timing field to its LogStreamTuning name', () => {
+    expect(
+      reconnectPolicyToTuning({
+        enabled: true,
+        initial: false,
+        minDelayMs: 100,
+        maxDelayMs: 10_000,
+        maxElapsedMs: 60_000,
+        stableAfterMs: 5_000,
+      })
+    ).toEqual({
+      backoffBaseMs: 100,
+      backoffMaxMs: 10_000,
+      reconnectBudgetMs: 60_000,
+      stableAfterMs: 5_000,
+    })
+  })
+
+  it('is unaffected by enabled/initial/shouldReconnect', () => {
+    expect(reconnectPolicyToTuning({ enabled: false, initial: true, shouldReconnect: () => true as const })).toEqual({})
+  })
+})

--- a/packages/sdk/src/core/ws/utils/reconnect-policy.ts
+++ b/packages/sdk/src/core/ws/utils/reconnect-policy.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod/v4'
+
+import { WsError, WsOptionsError } from '@/core/errors'
+
+import type { LogStreamTuning } from '../log-stream'
+
+/** Passed to `shouldReconnect` before each reconnect attempt (including the first, when `initial` is set). */
+export interface ShouldReconnectContext {
+  /** 1-based attempt about to run. */
+  attempt: number
+  /** Time (ms) spent reconnecting since the current drop. */
+  elapsedMs: number
+  /** Why the previous attempt — or the connection itself — failed. */
+  error: WsError
+}
+
+export interface ReconnectOptions {
+  /**
+   * Also retries a failed *first* connect instead of rejecting `connect*()`
+   * immediately. Default `false` — ADR-0016's default is that a first
+   * handshake failure (surviving one re-auth retry) fails loudly, since a
+   * misconfigured `baseUrl` or a panel that's down should not hang silently.
+   */
+  initial?: boolean
+  /** Total downtime budget (ms) before giving up. `Infinity` disables the budget — retries forever. */
+  maxElapsedMs?: number
+  /** How long a reconnected stream must stay open before backoff and the budget reset. */
+  stableAfterMs?: number
+  /** Base exponential-backoff delay (ms). */
+  minDelayMs?: number
+  /** Backoff delay cap (ms). */
+  maxDelayMs?: number
+  /**
+   * Full custom control over whether — and how long — to wait before the
+   * next attempt. `false` stops reconnecting; `true` or `undefined` accepts
+   * the computed backoff delay; a `number` overrides it.
+   */
+  shouldReconnect?: (ctx: ShouldReconnectContext) => boolean | number | undefined
+}
+
+/** `false` disables reconnecting entirely; `true` or an options object enables it, with any explicit overrides. */
+export type ReconnectOption = boolean | ReconnectOptions
+
+const reconnectOptionsSchema = z
+  .object({
+    initial: z.boolean().optional(),
+    // zod/v4's z.number() rejects Infinity outright — it has to be allowed explicitly.
+    maxElapsedMs: z.union([z.number().positive(), z.literal(Infinity)]).optional(),
+    stableAfterMs: z.number().positive().optional(),
+    minDelayMs: z.number().positive().optional(),
+    maxDelayMs: z.number().positive().optional(),
+    // zod/v4 has no schema for validating a plain function value as a field
+    // (z.function() builds a call/return contract, not a value validator).
+    shouldReconnect: z
+      .custom<(ctx: ShouldReconnectContext) => boolean | number | undefined>(value => typeof value === 'function', {
+        message: 'Expected a function',
+      })
+      .optional(),
+  })
+  .strict()
+
+/**
+ * Shared between per-call (`LogOptions.reconnect`, resolved by
+ * `resolveReconnectPolicy` — throws `WsOptionsError`) and SDK-level
+ * (`config.reconnect`, validated earlier by `configSchema` — throws
+ * `ConfigurationError`).
+ */
+export const reconnectOptionSchema = z.union([z.boolean(), reconnectOptionsSchema])
+
+export interface ResolvedReconnectPolicy {
+  enabled: boolean
+  initial: boolean
+  maxElapsedMs?: number
+  stableAfterMs?: number
+  minDelayMs?: number
+  maxDelayMs?: number
+  shouldReconnect?: (ctx: ShouldReconnectContext) => boolean | number | undefined
+}
+
+const DEFAULT_POLICY: ResolvedReconnectPolicy = { enabled: true, initial: false }
+
+/** Validates and resolves a `reconnect` option, defaulting to enabled with no explicit overrides. */
+export const resolveReconnectPolicy = (option?: ReconnectOption): ResolvedReconnectPolicy => {
+  if (option === undefined) return DEFAULT_POLICY
+
+  const { data, success, error } = reconnectOptionSchema.safeParse(option)
+  if (!success) {
+    throw new WsOptionsError(error.issues)
+  }
+
+  if (typeof data === 'boolean') return { enabled: data, initial: false }
+
+  return {
+    enabled: true,
+    initial: data.initial ?? false,
+    maxElapsedMs: data.maxElapsedMs,
+    stableAfterMs: data.stableAfterMs,
+    minDelayMs: data.minDelayMs,
+    maxDelayMs: data.maxDelayMs,
+    shouldReconnect: data.shouldReconnect,
+  }
+}
+
+/**
+ * Maps a resolved policy's explicit timing overrides onto `LogStreamTuning`
+ * field names — only the fields the caller actually set, so merging this
+ * into `{ ...DEFAULT_TUNING, ...reconnectPolicyToTuning(policy), ...tuning }`
+ * lets an internal test-only `tuning` override always win, and an unset
+ * policy field falls through to the module default rather than clobbering it.
+ */
+export const reconnectPolicyToTuning = (policy: ResolvedReconnectPolicy): Partial<LogStreamTuning> => {
+  const tuning: Partial<LogStreamTuning> = {}
+
+  if (policy.minDelayMs !== undefined) tuning.backoffBaseMs = policy.minDelayMs
+  if (policy.maxDelayMs !== undefined) tuning.backoffMaxMs = policy.maxDelayMs
+  if (policy.maxElapsedMs !== undefined) tuning.reconnectBudgetMs = policy.maxElapsedMs
+  if (policy.stableAfterMs !== undefined) tuning.stableAfterMs = policy.stableAfterMs
+
+  return tuning
+}

--- a/packages/sdk/src/core/ws/utils/replay.test.ts
+++ b/packages/sdk/src/core/ws/utils/replay.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWsOptionsError } from '@/core/errors'
+
+import { createReplayFilter, resolveReplayMode } from './replay'
+
+describe('resolveReplayMode', () => {
+  it('defaults to dedup when mode is undefined', () => {
+    expect(resolveReplayMode(undefined)).toBe('dedup')
+  })
+
+  it.each(['all', 'dedup', 'skip'] as const)('accepts %s', mode => {
+    expect(resolveReplayMode(mode)).toBe(mode)
+  })
+
+  it('throws a WsOptionsError recognized by its guard for an invalid mode', () => {
+    // @ts-expect-error deliberately invalid input
+    expect(() => resolveReplayMode('bogus')).toThrow()
+    try {
+      // @ts-expect-error deliberately invalid input
+      resolveReplayMode('bogus')
+      expect.unreachable()
+    } catch (error) {
+      expect(isWsOptionsError(error)).toBe(true)
+    }
+  })
+})
+
+describe('createReplayFilter', () => {
+  describe("mode: 'all'", () => {
+    it('always delivers by identity, armed or not, duplicate or not', () => {
+      const filter = createReplayFilter('all')
+      filter.arm()
+
+      const first = filter.accept('same line')
+      const second = filter.accept('same line')
+
+      expect(first).toEqual({ deliver: true, data: 'same line' })
+      expect(second).toEqual({ deliver: true, data: 'same line' })
+    })
+  })
+
+  describe('non-string payloads', () => {
+    it('passes a non-string payload through and disarms', () => {
+      const filter = createReplayFilter('dedup')
+      filter.arm()
+
+      const result = filter.accept(new ArrayBuffer(4))
+
+      expect(result.deliver).toBe(true)
+      // Disarmed: a following duplicate string is no longer suppressed either.
+      filter.accept('line one')
+      const after = filter.accept('line one')
+      expect(after).toEqual({ deliver: true, data: 'line one' })
+    })
+  })
+
+  describe("mode: 'dedup'", () => {
+    it('records lines and delivers by identity while not armed, even for a repeated line', () => {
+      const filter = createReplayFilter('dedup')
+
+      const first = filter.accept('line one')
+      const second = filter.accept('line one')
+
+      expect(first).toEqual({ deliver: true, data: 'line one' })
+      expect(second).toEqual({ deliver: true, data: 'line one' })
+    })
+
+    it('records a multi-line, trailing-newline message correctly (an empty trailing segment is never indexed)', () => {
+      const filter = createReplayFilter('dedup')
+      filter.accept('line one\nline two\n')
+      filter.arm()
+
+      // The trailing empty segment must not make an empty replayed line look "new".
+      const result = filter.accept('line one\nline two\n')
+
+      expect(result).toEqual({ deliver: false })
+    })
+
+    it('suppresses a fully-duplicate replayed frame and stays armed', () => {
+      const filter = createReplayFilter('dedup')
+      filter.accept('line one')
+      filter.accept('line two')
+      filter.arm()
+
+      const result = filter.accept('line one\nline two')
+
+      expect(result).toEqual({ deliver: false })
+    })
+
+    it('delivers an entirely new frame by identity and disarms', () => {
+      const filter = createReplayFilter('dedup')
+      filter.accept('line one')
+      filter.arm()
+
+      const result = filter.accept('a brand new line')
+
+      expect(result).toEqual({ deliver: true, data: 'a brand new line' })
+
+      // Disarmed: a duplicate delivered next is no longer suppressed.
+      const next = filter.accept('line one')
+      expect(next).toEqual({ deliver: true, data: 'line one' })
+    })
+
+    it('drops the leading duplicate run of a mixed frame and delivers the rest, rejoined', () => {
+      const filter = createReplayFilter('dedup')
+      filter.accept('line one')
+      filter.accept('line two')
+      filter.arm()
+
+      const result = filter.accept('line one\nline two\nline three')
+
+      expect(result).toEqual({ deliver: true, data: 'line three' })
+    })
+
+    it('never suppresses a legitimately repeated line while not armed', () => {
+      const filter = createReplayFilter('dedup')
+
+      const results = ['OK', 'OK', 'OK'].map(line => filter.accept(line))
+
+      expect(results).toEqual([
+        { deliver: true, data: 'OK' },
+        { deliver: true, data: 'OK' },
+        { deliver: true, data: 'OK' },
+      ])
+    })
+
+    it('empty payload while armed stays suppressed and keeps the window armed', () => {
+      const filter = createReplayFilter('dedup')
+      filter.accept('line one')
+      filter.arm()
+
+      const result = filter.accept('')
+
+      expect(result).toEqual({ deliver: false })
+
+      // Still armed: a genuine duplicate right after is still suppressed too.
+      const next = filter.accept('line one')
+      expect(next).toEqual({ deliver: false })
+    })
+
+    it('forgets a line once its last occurrence is evicted from the ring, but not a duplicate still inside it', () => {
+      const filter = createReplayFilter('dedup', 2)
+
+      filter.accept('a')
+      filter.accept('a') // ring: [a, a] — at capacity, not yet evicted
+      filter.accept('b') // evicts the oldest 'a': one occurrence remains (count 2 -> 1)
+      filter.accept('c') // evicts the last 'a': now fully forgotten (count 1 -> deleted)
+
+      filter.arm()
+      const result = filter.accept('a')
+
+      // 'a' was fully evicted — this is a genuinely new line, not a replay.
+      expect(result).toEqual({ deliver: true, data: 'a' })
+    })
+
+    it('force-disarms once the hard cap of scanned lines is reached, flushing the remainder even if it too was seen', () => {
+      const filter = createReplayFilter('dedup', 3)
+      // All three fit the ring (bufferLines 3) without evicting each other.
+      ;['L1', 'L2', 'L3'].forEach(line => filter.accept(line))
+      filter.arm()
+
+      const result = filter.accept('L1\nL2\nL3\nL1\nL2')
+
+      // The 4th line (a repeated L1) crosses the cap (scanned count 4 >
+      // bufferLines 3): the window force-disarms there, so the 5th line
+      // (L2) flows through too even though it was also previously delivered.
+      expect(result).toEqual({ deliver: true, data: 'L2' })
+    })
+  })
+
+  describe("mode: 'skip'", () => {
+    it('drops the whole message when it contains any previously delivered line, and stays armed', () => {
+      const filter = createReplayFilter('skip')
+      filter.accept('line one')
+      filter.arm()
+
+      const result = filter.accept('line one\nline two')
+
+      expect(result).toEqual({ deliver: false })
+    })
+
+    it('delivers the first message with no previously delivered line, by identity, and disarms', () => {
+      const filter = createReplayFilter('skip')
+      filter.accept('line one')
+      filter.arm()
+
+      const result = filter.accept('a brand new line')
+
+      expect(result).toEqual({ deliver: true, data: 'a brand new line' })
+
+      const next = filter.accept('line one')
+      expect(next).toEqual({ deliver: true, data: 'line one' })
+    })
+
+    it('degenerates to per-line dedup at interval 0 (one line per message)', () => {
+      const filter = createReplayFilter('skip')
+      filter.accept('line one')
+      filter.arm()
+
+      const first = filter.accept('line one')
+      const second = filter.accept('a brand new line')
+
+      expect(first).toEqual({ deliver: false })
+      expect(second).toEqual({ deliver: true, data: 'a brand new line' })
+    })
+
+    it('force-disarms and delivers the whole message once the hard cap is reached, even though it still contains a seen line', () => {
+      const filter = createReplayFilter('skip', 2)
+      filter.accept('x')
+      filter.accept('y')
+      filter.arm()
+
+      const result = filter.accept('x\ny\nz')
+
+      expect(result).toEqual({ deliver: true, data: 'x\ny\nz' })
+    })
+  })
+
+  describe('arm()', () => {
+    it('re-arming resets the scanned-lines cap for a fresh window', () => {
+      const filter = createReplayFilter('dedup', 1)
+      filter.accept('a')
+      filter.arm()
+
+      // Trips the cap on the first window (scanned count 2 > bufferLines 1),
+      // forcing a disarm partway through.
+      filter.accept('a\na')
+
+      filter.accept('b')
+      filter.arm()
+      // A fresh window: the cap must not carry over from the previous arm().
+      const result = filter.accept('b')
+
+      expect(result).toEqual({ deliver: false })
+    })
+  })
+})

--- a/packages/sdk/src/core/ws/utils/replay.ts
+++ b/packages/sdk/src/core/ws/utils/replay.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod/v4'
+
+import { DEFAULT_WS_REPLAY, WS_REPLAY_BUFFER_LINES } from '@/config'
+import { WsOptionsError } from '@/core/errors'
+
+export type ReplayMode = 'all' | 'dedup' | 'skip'
+
+const replayModeSchema = z.enum(['all', 'dedup', 'skip'])
+
+/**
+ * Validates `LogOptions.replay`, defaulting to `'dedup'` — the panel
+ * re-delivers up to 100 already-seen lines on every reconnect (see
+ * docs/marzban-quirks.md), and `'dedup'` is what suppresses that.
+ */
+export const resolveReplayMode = (mode: ReplayMode = DEFAULT_WS_REPLAY): ReplayMode => {
+  const { data, success, error } = replayModeSchema.safeParse(mode)
+
+  if (!success) {
+    throw new WsOptionsError(error.issues)
+  }
+
+  return data
+}
+
+export type ReplayDecision = { deliver: true; data: unknown } | { deliver: false }
+
+export interface ReplayFilter {
+  /** Arms the suppression window — called on a transport drop, never on the first connect. */
+  arm(): void
+  /** Decides whether `data` should reach the consumer, applying and updating the current window. */
+  accept(data: unknown): ReplayDecision
+}
+
+/**
+ * Filters replayed log lines after a reconnect — the panel re-seeds every
+ * new connection from a shared, cursor-less buffer of its last ~100 lines
+ * (docs/marzban-quirks.md), and a batching `interval > 0` joins several
+ * lines into one message, so filtering has to operate per *line*, not per
+ * message: the replay's batching never lines up with the live stream's.
+ *
+ * The window is armed only by `arm()` (a drop) and disarms itself the moment
+ * genuinely new content is seen, rather than staying open indefinitely — so
+ * a line that legitimately repeats (a heartbeat, `"OK"`) is never dropped
+ * once the replay has actually been worked through. A hard cap
+ * (`bufferLines` lines scanned while armed) forces a disarm regardless, so a
+ * stream of identical lines can never hold the window open forever.
+ */
+export const createReplayFilter = (mode: ReplayMode, bufferLines: number = WS_REPLAY_BUFFER_LINES): ReplayFilter => {
+  // Ring of the last `bufferLines` delivered lines, with counts rather than
+  // a plain Set: evicting one occurrence of a line that recurs legitimately
+  // must not forget every other occurrence still in the window.
+  const ring: string[] = []
+  const counts = new Map<string, number>()
+  let armed = false
+  let scannedWhileArmed = 0
+
+  /** An empty segment is always droppable while armed; a non-empty one only if it was actually delivered before. */
+  const isSuppressible = (line: string): boolean => line === '' || counts.has(line)
+
+  const recordLine = (line: string): void => {
+    if (line === '') return
+    ring.push(line)
+    counts.set(line, (counts.get(line) ?? 0) + 1)
+
+    if (ring.length > bufferLines) {
+      const evicted = ring.shift()!
+      const remaining = counts.get(evicted)! - 1
+      if (remaining <= 0) counts.delete(evicted)
+      else counts.set(evicted, remaining)
+    }
+  }
+
+  /** Drops the leading run of suppressible lines; the first genuinely new one disarms and passes through with the rest. */
+  const acceptDedup = (lines: string[], data: string): ReplayDecision => {
+    let cursor = 0
+    let stayArmed = true
+
+    for (; cursor < lines.length; cursor++) {
+      if (!isSuppressible(lines[cursor]!)) {
+        stayArmed = false
+        break
+      }
+      scannedWhileArmed++
+      if (scannedWhileArmed > bufferLines) {
+        stayArmed = false
+        cursor++
+        break
+      }
+    }
+    armed = stayArmed
+
+    const kept = lines.slice(cursor)
+    kept.forEach(recordLine)
+
+    if (kept.length === 0) return { deliver: false }
+    // Nothing dropped: return the original payload by identity, not a rejoined copy.
+    return cursor === 0 ? { deliver: true, data } : { deliver: true, data: kept.join('\n') }
+  }
+
+  /** Drops the whole message if any of its lines was already delivered; the first clean message disarms. */
+  const acceptSkip = (lines: string[], data: string): ReplayDecision => {
+    const hasSuppressibleLine = lines.some(isSuppressible)
+    scannedWhileArmed += lines.length
+
+    if (hasSuppressibleLine && scannedWhileArmed <= bufferLines) return { deliver: false }
+
+    armed = false
+    lines.forEach(recordLine)
+    return { deliver: true, data }
+  }
+
+  return {
+    arm() {
+      armed = true
+      scannedWhileArmed = 0
+    },
+    accept(data) {
+      if (mode === 'all') return { deliver: true, data }
+
+      // Binary frames are uncomparable — stop suppressing rather than guess.
+      if (typeof data !== 'string') {
+        armed = false
+        return { deliver: true, data }
+      }
+
+      const lines = data.split('\n')
+
+      if (!armed) {
+        lines.forEach(recordLine)
+        return { deliver: true, data }
+      }
+
+      return mode === 'dedup' ? acceptDedup(lines, data) : acceptSkip(lines, data)
+    },
+  }
+}

--- a/packages/sdk/src/core/ws/utils/stream-handle.test.ts
+++ b/packages/sdk/src/core/ws/utils/stream-handle.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createStreamHandle } from './stream-handle'
+
+describe('createStreamHandle', () => {
+  it('is callable and closing it closes the source', () => {
+    const close = vi.fn()
+    const handle = createStreamHandle({ close, state: 'open' as const })
+
+    handle()
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes an explicit close() that closes the source', () => {
+    const close = vi.fn()
+    const handle = createStreamHandle({ close, state: 'open' as const })
+
+    handle.close()
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads state live — a change on the source is visible without re-wrapping', () => {
+    const source = { close: vi.fn(), state: 'connecting' as string }
+    const handle = createStreamHandle(source)
+
+    expect(handle.state).toBe('connecting')
+
+    source.state = 'closed'
+
+    expect(handle.state).toBe('closed')
+  })
+
+  it('is a function', () => {
+    const handle = createStreamHandle({ close: vi.fn(), state: 'open' as const })
+
+    expect(typeof handle).toBe('function')
+  })
+})

--- a/packages/sdk/src/core/ws/utils/stream-handle.ts
+++ b/packages/sdk/src/core/ws/utils/stream-handle.ts
@@ -1,0 +1,31 @@
+/**
+ * A logical stream's public handle: callable (closes it, for source
+ * compatibility with the bare close function this replaces), with an
+ * explicit `close()` and a live `state`.
+ */
+export type StreamHandle<S> = {
+  (): void
+  close(): void
+  readonly state: S
+}
+
+/** Anything a {@link StreamHandle} can wrap — matches `LogStream` structurally. */
+export interface StreamHandleSource<S> {
+  close(): void
+  readonly state: S
+}
+
+/**
+ * Wraps `source` in a {@link StreamHandle}.
+ *
+ * `state` must be a live getter, not a snapshot — `Object.assign` would copy
+ * the *value* at creation time, freezing `handle.state` at whatever `source`
+ * reported the moment this ran. `Object.defineProperty` with a getter reads
+ * `source.state` on every access instead.
+ */
+export const createStreamHandle = <S>(source: StreamHandleSource<S>): StreamHandle<S> => {
+  const handle = (() => source.close()) as StreamHandle<S>
+  handle.close = () => source.close()
+  Object.defineProperty(handle, 'state', { get: () => source.state, enumerable: true })
+  return handle
+}


### PR DESCRIPTION
## Summary

Closes #89 — the public surface for the WS log-stream reconnect work from #88/ADR-0016. Five commits, each independently green (100% coverage):

- **Callable stream handle**: `connect*()` resolves to `{ (): void; close(): void; readonly state }` instead of a bare close function (source-compatible).
- **Typed lifecycle callbacks**: `onError` receives a `WsError` instead of a raw transport event; new `onOpen`, `onReconnect({ attempt, downtimeMs })`, `onClose({ code, byCaller })` — `onClose` fires exactly once per logical stream, only if it ever reached `open` (ADR-0016's "reported exactly once").
- **`replay: 'all' | 'dedup' | 'skip'`** (default `'dedup'`): the panel re-delivers up to ~100 already-seen lines on every reconnect; the new filter suppresses them per line (not per message — batching never lines up between the live stream and the replay), armed only by a drop and disarmed by the first genuinely new line, so a legitimately repeating line is never swallowed.
- **Public `reconnect` policy**: per call (`LogOptions.reconnect`) and SDK-wide (`createMarzbanSDK({ reconnect })`). `false` disables it; `initial` retries a failed first connect too; `maxElapsedMs`/`stableAfterMs`/`minDelayMs`/`maxDelayMs` override the timing defaults; `shouldReconnect(ctx)` gives full custom control. The internal `tuning` test seam is untouched — it always wins over the resolved policy's timing fields.
- **`Authorization: Bearer` on the `ws`-package transport**: verified against `gozargah/marzban:v0.8.4`'s own source (`query_params.get("token") or headers.get("Authorization").removeprefix("Bearer ")`) and against a live local panel — the access log shows no `token=` at all. The native `WebSocket` constructor (browsers, Deno, Bun, Node 21+) has no headers option, so it still carries the token in the URL — a platform limit, not a gap.

Also adds [ADR-0017](docs/adr/0017-ws-public-stream-surface.md) recording the four real decisions behind this (line-level dedup window, `onClose` semantics, public `reconnect` vs internal `tuning`, header-auth transport split), and brings the WebSocket Logs guide, error codes reference, type glossary, `marzban-quirks.md`, and `testing.md` up to date.

Deliberately **not** in this PR: `CHANGELOG.md` (fully git-cliff generated — never hand-edited in this repo's history) and the v3→v4 migration guide (better composed once across every breaking change in the `sdk-v4.0.0` milestone, not per-issue).

## Test plan

- [x] `pnpm --filter marzban-sdk test:coverage` — 896 tests, 100% statements/branches/functions/lines
- [x] `pnpm --filter marzban-sdk lint` / `types:check` / `build` — clean, new public types land in `dist/index.d.ts`
- [x] `pnpm --filter marzban-sdk-docs types:check` — clean after the `.mdx`/type-glossary edits
- [x] `pnpm --filter marzban-sdk test:integration` against the local panel — `logs.integration.test.ts` (3/3) exercises the real header-auth path live (integration helpers always force the `ws`-package transport via `httpsAgent`)
- [x] Verified live: panel source confirms the `Authorization` header contract; the panel's own access log confirms no token in the query string on that transport