### PR TITLE
docs: v4 history entry and v3→v4 migration guide

### DIFF
--- a/apps/docs/content/docs/resources/migration.mdx
+++ b/apps/docs/content/docs/resources/migration.mdx
@@ -1,7 +1,98 @@
 ---
 title: Migration guide
-description: Step-by-step guide for migrating MarzbanSDK from v2 to v3.0.0, covering the async webhook API and server-side-only signature verification — the only breaking release in the SDK's history so far.
+description: Step-by-step guides for migrating MarzbanSDK across its breaking releases — v3.0.0's async webhook API, and v4.0.0's WebSocket reconnect lifecycle and destroy() contract.
 ---
+
+## v3.0.0 → v4.0.0
+
+Shipped in `marzban-sdk@4.0.0`, bundling three issues that all forced the same major:
+[#84](https://github.com/Ilmar7786/marzban-sdk/issues/84) (a terminal `destroy()` lifecycle contract),
+[#88](https://github.com/Ilmar7786/marzban-sdk/issues/88) (a WebSocket reconnect state machine
+replacing `sdk.logs`'s "request that either succeeds or fails" model), and
+[#89](https://github.com/Ilmar7786/marzban-sdk/issues/89) (the resulting public surface — lifecycle
+callbacks, replay dedup, header auth). See
+[ADR-0015](https://github.com/Ilmar7786/marzban-sdk/blob/main/docs/adr/0015-sdk-destroy-terminal-lifecycle.md),
+[ADR-0016](https://github.com/Ilmar7786/marzban-sdk/blob/main/docs/adr/0016-ws-stream-lifecycle-and-reconnect.md),
+and [ADR-0017](https://github.com/Ilmar7786/marzban-sdk/blob/main/docs/adr/0017-ws-public-stream-surface.md)
+for the full design rationale.
+
+**Breaking changes:**
+
+- **A failed first `connect*()` now rejects instead of resolving.** Previously it always resolved with
+  a close handle, even to a socket that never opened.
+- **`connect*()` resolves only once the socket is genuinely `open`,** not merely constructed.
+- **`onError` receives a `WsError`, never a raw DOM event.** `err.url` is redacted; it never carries the
+  access token.
+- **`replay: 'dedup'` is the new default,** suppressing log lines the panel re-delivers after a
+  reconnect. If you relied on seeing every replayed line, opt into `replay: 'all'`.
+- **`LogsStreamOptions.maxRetries` is gone.** WS reconnects use their own internal time budget instead
+  of `config.retries`; there's no equivalent option to set.
+- **Any SDK operation called after `destroy()` now rejects with `SdkDestroyedError`** instead of
+  silently succeeding or (for WS) silently reconnecting: `authorize()`, `getAuthToken()`,
+  `logs.connect*()`, and `webhook.parseWebhook()`/`handleWebhook()`/`dispatch()`.
+  `webhook.on()`/`once()`/`off()` are unaffected — unsubscribing after shutdown still works.
+
+See the [Changelog](/docs/resources/changelog) for full release notes.
+
+### 1. Handle a rejected first connect
+
+```ts
+// v3 — always resolved, even on a failed handshake
+const stream = await sdk.logs.connectByCore({ onMessage: handler })
+
+// v4 — a failed first connect now rejects; handle it
+try {
+  const stream = await sdk.logs.connectByCore({ onMessage: handler })
+} catch (err) {
+  if (isWsError(err)) console.error('Failed to connect:', err.code, err.message)
+}
+```
+
+### 2. Update onError handlers to expect a WsError
+
+```ts
+// v3 — a raw DOM event, potentially carrying the token in event.target.url
+onError: (event) => console.error(event.message)
+
+// v4 — a typed, redacted error
+onError: (error: WsError) => console.error(error.code, error.message)
+```
+
+### 3. Opt back into every replayed line, if you relied on it
+
+```ts
+// v4 default is 'dedup' — add this to restore v3's behavior
+await sdk.logs.connectByCore({ onMessage: handler, replay: 'all' })
+```
+
+### 4. Drop maxRetries, use the reconnect option if you need custom timing
+
+```ts
+// v3
+await sdk.logs.connectByCore({ onMessage: handler, maxRetries: 5 })
+
+// v4 — reconnects are budget-based, not attempt-based; shouldReconnect gives full control
+await sdk.logs.connectByCore({
+  onMessage: handler,
+  reconnect: { shouldReconnect: ({ attempt }) => attempt <= 5 },
+})
+```
+
+### 5. Catch SdkDestroyedError for calls that might race a shutdown
+
+```ts
+await sdk.destroy()
+
+// v3 — this would silently succeed or hang
+// v4 — rejects with SdkDestroyedError
+try {
+  await sdk.authorize()
+} catch (err) {
+  if (isSdkDestroyedError(err)) {
+    /* expected post-shutdown */
+  }
+}
+```
 
 ## v2 → v3.0.0
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -74,9 +74,30 @@ stderr-only logger stream (stdout is reserved for JSON-RPC), so `index.ts`
 gained a `Logger` type export, `ERROR_CODES`, `redactSecrets`, and
 `validateConfig` as named exports, and `HttpError` gained typed accessors.
 
+## 9. WebSocket reconnect lifecycle, `destroy()` contract, and the v4.0.0 public surface (2026-09, breaking)
+
+`sdk.logs`'s WebSocket streams had no reconnect behavior: a dropped connection
+died silently, a rejected handshake was retried by matching the substring
+`'403'` in an error message (dead on the native `WebSocket`, which reports no
+message at all), and `destroy()` could resolve while a reconnect already in
+flight went on to open a new socket. Replaced with a `LogStream` state machine
+(`connecting → open → reconnecting → closed`) that classifies failures by
+connection phase instead of error text, reconnects with backoff bounded by a
+time budget, and checks a generation guard after every `await` — the same
+invariant a SDK-wide `Lifecycle` flag now uses to make `destroy()` idempotent
+and cancel in-flight WS work, with each subsystem's cleanup (WS, webhook,
+auth) running independently of the others' failures. The public surface
+followed: `WsError` instead of a raw DOM event, `onOpen`/`onReconnect`/
+`onClose` lifecycle callbacks, `replay: 'dedup'` to suppress the panel's
+re-delivered log lines after a reconnect, a public `reconnect` policy, and the
+access token moving to an `Authorization` header on the `ws`-package
+transport. See [ADR-0015](./adr/0015-sdk-destroy-terminal-lifecycle.md),
+[ADR-0016](./adr/0016-ws-stream-lifecycle-and-reconnect.md), and
+[ADR-0017](./adr/0017-ws-public-stream-surface.md).
+
 ## Where things stand
 
-The monorepo migration lives on `dev` and has not yet merged to `main` — CI
-and publish workflows on `main` are still the pre-monorepo, single-package
-versions. The `sdk-v*`/`mcp-v*` tag scheme is declared in `publish.yml` but
-hasn't produced a tag yet; the most recent actual release tag is `v3.0.1`.
+The monorepo pipeline (item 7) has been live for a while — `main` has shipped
+several releases through it since, most recently `sdk-v3.3.0`. `sdk-v4.0.0`
+(item 9 above) is complete on `dev` but not yet released: the version bump and
+`dev` → `main` merge are the last steps of the release checklist.


### PR DESCRIPTION
## Summary

Part of #121 — the first two checklist items: the `docs/history.md` entry for the v4 era, and the
`v3.0.0 → v4.0.0` section in the migration guide. Both were deliberately deferred out of #84/#88/#89/#90
individually since they only make sense composed once, across the whole milestone.

- **`docs/history.md`**: new entry (item 9) covering the WS reconnect state machine, the SDK-wide
  `destroy()` lifecycle contract, and the resulting public surface — linking ADR-0015/0016/0017. Also
  updated the "Where things stand" closing section, which was stale (still describing the pre-monorepo
  state on `main`, even though several releases have shipped through the monorepo pipeline since).
- **`migration.mdx`**: new `v3.0.0 → v4.0.0` section, same before/after style as the existing
  `v2 → v3.0.0` guide — six breaking changes with code examples (rejected first `connect*()`, `WsError`
  through `onError`, `replay: 'dedup'` default, removed `maxRetries`, `SdkDestroyedError` after
  `destroy()`).

Not in this PR (remaining #121 items): the actual version bump, `dev` → `main` merge, and release-pipeline
verification — those come after this lands.

## Test plan

- [x] `pnpm --filter marzban-sdk-docs types:check` — clean
- [x] Verified `isWsError`/`isSdkDestroyedError` (used in the new migration examples) are real exports
      from the SDK's public barrel
