### PR TITLE
fix(mcp): stop MCP output schemas rejecting Marzban's real datetimes

### DIFF
--- a/docs/adr/0018-mcp-output-schemas-no-format-keyword.md
+++ b/docs/adr/0018-mcp-output-schemas-no-format-keyword.md
@@ -1,0 +1,103 @@
+# ADR-0018: MCP `outputSchema`s never emit a JSON Schema `format` keyword
+
+Status: Accepted
+Date: 2026-09-05
+
+## Context
+
+Marzban returns datetime fields without a UTC offset —
+`created_at: "2026-09-02T14:00:57.764445"`, no `Z`, no `+00:00`.
+`packages/sdk/kubb.config.ts` deliberately generates these as
+`z.iso.datetime({ local: true })` (`dateType: 'stringLocal'`) so the SDK can
+parse that shape — the right choice on the SDK side, where the schema's job
+is to accept what the wire actually sends.
+
+`packages/mcp` reused those same SDK response schemas — `userResponseSchema`,
+`subscriptionUserResponseSchema` — wholesale as MCP `outputSchema`s, for
+every tool returning a user (`users_get/create/list/update/activate/
+deactivate/hold/extend/revoke_subscription`, `subscription_info`). This is
+exactly what `packages/mcp/ARCHITECTURE.md`'s "add a tool" instructions told
+authors to do: "reuse SDK-exported schemas where possible."
+
+The problem: `z.iso.datetime({ local: true })` converts to JSON Schema as
+`{ type: "string", format: "date-time", pattern: "...(?:Z|)$" }`. The
+`pattern` already accepts a missing offset — but `format: "date-time"` is an
+RFC 3339 claim that an offset is present, and a format-aware validator keys
+off `format`, not `pattern`. A strict MCP client (confirmed with Claude
+Desktop) validates `structuredContent` against the tool's advertised
+`outputSchema` and rejects Marzban's real response, even though the
+underlying operation succeeded (github.com/Ilmar7786/marzban-sdk#112).
+Reproduced live: `marzban_users_create` created the user; the client showed
+`created_at must match format "date-time"` instead of the result.
+
+Neither of the two test layers that should have caught this actually could:
+
+- Every MCP fixture used `created_at: '2026-01-01T00:00:00Z'` — a shape
+  Marzban never sends — so `.safeParse()` never saw the real value.
+- `.safeParse()` wouldn't have caught it even with the real value: zod parses
+  an offset-less string identically whether `local: true` is set or not.
+  Nothing in the unit suite ever inspected the _emitted JSON Schema_, which
+  is where `format` actually lives — the bug is entirely at the boundary
+  between "zod accepts this" and "a JSON-Schema-`format` validator accepts
+  this," a boundary this codebase had never tested.
+
+## Decision
+
+No tool's `outputSchema` may emit a JSON Schema `format` keyword, for any
+field, full stop — not just the four datetime fields this issue found.
+
+- `shared/schemas.ts` exports `mcpUserResponseSchema` /
+  `mcpSubscriptionUserResponseSchema`: the SDK response schema with
+  `created_at`/`sub_updated_at`/`online_at`/`on_hold_timeout` overridden to
+  plain `z.string()` via `.extend()`. Every other field — including ones
+  added to the SDK schema later — is inherited unchanged; only those four are
+  hand-listed.
+- `output-schema-regression.test.ts` iterates every tool in `allTools` and
+  asserts the JSON Schema `@modelcontextprotocol/server` would actually
+  derive from its `outputSchema` (via the new `toolOutputJsonSchema` helper,
+  `schema['~standard'].jsonSchema.output(...)` — the same path the server
+  itself uses) contains no `format` key anywhere, at any depth. This is
+  deliberately broader than the four fields found: it closes the door on
+  `format: "email"`/`"uri"`/`"ipv4"`/etc. leaking the same way through a
+  different SDK schema or a tool not yet written, not just this one symptom.
+- A real ajv instance (`ajv` + `ajv-formats`, new devDependencies in
+  `packages/mcp`) with format assertions on validates a real tool result
+  against its derived JSON Schema in `smoke.integration.test.ts` — the one
+  check that actually reproduces what a strict client does, since
+  `.safeParse()` structurally cannot.
+- `ARCHITECTURE.md`'s "add a tool" step 1 is corrected: reusing an SDK schema
+  for an `outputSchema` is fine for structure, never for a field's format
+  claim — point to the `mcp*ResponseSchema` exports for response types.
+
+Rejected: overriding only the four known fields with no blanket test. It
+would have closed exactly this bug and left the class of bug open — the SDK
+generates several other schemas with the same `local: true` shape
+(`userCreateSchema`, `userModifySchema`, the expired-users list schemas)
+that happen not to be reused as `outputSchema`s today, and nothing would stop
+a future tool from reusing one the same wholesale way.
+
+Also rejected: a generic recursive transform that auto-detects and rewrites
+any datetime-shaped leaf in an arbitrary zod schema. It would sync automatically
+with future SDK schema changes, but zod v4 has no stable "walk this schema's
+def" API to build that on — the regression test plus the hand-listed
+`.extend()` override gets the same practical safety (nothing ships with a
+stray `format`) without depending on zod internals that could shift under a
+minor version bump.
+
+## Consequences
+
+- `mcpUserResponseSchema`/`mcpSubscriptionUserResponseSchema` are now the
+  required entry point for any MCP output schema that represents a Marzban
+  user — a new tool reusing `userResponseSchema` from `marzban-sdk` directly
+  reintroduces the bug the regression test exists to catch, and the test
+  will fail on that tool's own name.
+- A genuinely new datetime (or other format-bearing) field added to
+  `userResponseSchema`/`subscriptionUserResponseSchema` upstream is **not**
+  automatically wire-honest — it needs adding to the `.extend()` override by
+  hand. `output-schema-regression.test.ts` is what turns that omission into a
+  failing test instead of a silent recurrence, the moment such a field is
+  exposed through any tool's `outputSchema`.
+- Any future, deliberate use of `format` in an `outputSchema` (a field this
+  codebase can actually verify the wire format backs up) needs its own commit
+  adding a narrow, documented exception to the regression test — never folded
+  into an unrelated change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,4 @@ What this enables, what it costs.
 | [0015](./0015-sdk-destroy-terminal-lifecycle.md)                     | `MarzbanSDK.destroy()` is a terminal lifecycle transition           |
 | [0016](./0016-ws-stream-lifecycle-and-reconnect.md)                  | WebSocket stream lifecycle and reconnect policy                     |
 | [0017](./0017-ws-public-stream-surface.md)                           | WS stream public surface — replay, reconnect, and header auth       |
+| [0018](./0018-mcp-output-schemas-no-format-keyword.md)               | MCP `outputSchema`s never emit a JSON Schema `format` keyword       |

--- a/docs/marzban-quirks.md
+++ b/docs/marzban-quirks.md
@@ -470,3 +470,29 @@ after a reconnect. Per-line, not per-message: a batching `interval > 0`
 joins several lines into one message on the live stream, but the panel's
 replay buffer has no such grouping, so the two never line up. See
 [ADR-0017](./adr/0017-ws-public-stream-surface.md).
+
+## User-object datetime fields come back without a UTC offset
+
+**Verified against:** `gozargah/marzban:v0.8.4`, `local/marzban/`, the
+published `ilmar7786/marzban-mcp` Docker image wired into Claude Desktop.
+
+`created_at`, `sub_updated_at`, `online_at`, and `on_hold_timeout` on
+`UserResponse`/`SubscriptionUserResponse` are plain naive-datetime strings —
+`"2026-09-02T14:00:57.764445"` — never `Z`, never `+00:00`. Confirmed via a
+direct `GET /api/user/{username}` call with the admin token right after
+`addUser`.
+
+This is fine for the SDK, which parses these fields with
+`z.iso.datetime({ local: true })` specifically because of this
+(`packages/sdk/kubb.config.ts`). It stopped being fine at the MCP boundary:
+`packages/mcp` reused those same SDK schemas as tool `outputSchema`s, and
+`local: true` still lowers to a JSON Schema `format: "date-time"` — an
+RFC 3339 claim of an offset that isn't there. A strict MCP client validating
+`structuredContent` against that schema rejected every real response
+(github.com/Ilmar7786/marzban-sdk#112).
+
+**Workaround:** none needed on the SDK side — `local: true` is correct there.
+At the MCP boundary, use `mcpUserResponseSchema`/
+`mcpSubscriptionUserResponseSchema` (`packages/mcp/src/shared/schemas.ts`),
+which override these four fields to plain `z.string()`. See
+[ADR-0018](./adr/0018-mcp-output-schemas-no-format-keyword.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,10 +54,15 @@ pnpm --filter marzban-sdk test:coverage
   suite stays deliberately smaller than `sdk`'s — not a re-run of `sdk`'s
   edge cases, since the mocked-SDK unit tests in `packages/mcp/src/modules/**`
   already prove each tool calls the SDK correctly; what they can't catch is
-  drift between an MCP tool's zod schema and the SDK's real types.
-  `smoke.integration.test.ts` covers that at the smallest scope: one
-  passthrough tool, one with MCP-only logic, one destructive tool through
-  the confirm-flow. `users-lifecycle.integration.test.ts` covers the full
+  drift between an MCP tool's zod schema and the SDK's real types — including
+  drift a mocked `.safeParse()` can't see at all, like an `outputSchema`
+  claiming a JSON Schema `format` a real response value doesn't hold to (see
+  ADR-0018 and the `output-schema-regression.test.ts` unit test for the rest
+  of that guard). `smoke.integration.test.ts` covers that at the smallest
+  scope: one passthrough tool, one with MCP-only logic, one destructive tool
+  through the confirm-flow, one output validated against a real ajv instance
+  the way a strict MCP client validates `structuredContent`.
+  `users-lifecycle.integration.test.ts` covers the full
   path GitHub issue #65's Definition of Done asked for — create → extend →
   deactivate → activate → usage → delete through the actual MCP tools, plus
   reading and dry-running a core config change. Real Marzban behavior these

--- a/packages/mcp/ARCHITECTURE.md
+++ b/packages/mcp/ARCHITECTURE.md
@@ -214,9 +214,17 @@ an explicit marker — a silent cut reads to the model as "this is everything."
 To add a tool:
 
 1. Add `xxxInputSchema`/`xxxOutputSchema` (Zod v4) to
-   `modules/<area>/<area>.schemas.ts` — reuse SDK-exported schemas where
-   possible. `outputSchema` must be a single object type. Destructive tools
-   need a `confirmToken` field.
+   `modules/<area>/<area>.schemas.ts` — reuse SDK-exported schemas for
+   structure where possible, but never for an `outputSchema`'s format claims:
+   an SDK schema is written to _parse_ Marzban's response and can carry a
+   JSON Schema `format` (e.g. `date-time`) the wire format doesn't actually
+   guarantee — see ADR-0018. For a response containing a Marzban user, use
+   `mcpUserResponseSchema`/`mcpSubscriptionUserResponseSchema` from
+   `shared/schemas.ts` instead of `userResponseSchema`/
+   `subscriptionUserResponseSchema` directly. `output-schema-regression.test.ts`
+   fails on any tool whose `outputSchema` emits `format` at all, so this is
+   enforced, not just documented. `outputSchema` must be a single object
+   type. Destructive tools need a `confirmToken` field.
 2. Add a `View<T>` to `modules/<area>/<area>.views.ts`.
 3. Call `defineTool({...})` in `modules/<area>/<area>.tools.ts`. The tool
    name must start with `marzban_`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -50,6 +50,8 @@
   "devDependencies": {
     "@types/node": "^26.2.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^6.1.1",

--- a/packages/mcp/src/core/tool/index.ts
+++ b/packages/mcp/src/core/tool/index.ts
@@ -1,5 +1,6 @@
 export type { ToolContext } from './context'
 export { defineTool, type ToolDefinition, type ToolScope } from './define-tool'
+export { toolOutputJsonSchema } from './json-schema'
 export {
   alwaysProceed,
   type ConfirmDecision,

--- a/packages/mcp/src/core/tool/json-schema.test.ts
+++ b/packages/mcp/src/core/tool/json-schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { toolOutputJsonSchema } from './json-schema'
+
+describe('toolOutputJsonSchema', () => {
+  it('converts a zod schema to the draft-2020-12 JSON Schema a client would see', () => {
+    const schema = z.object({ ok: z.boolean() })
+
+    expect(toolOutputJsonSchema(schema)).toMatchObject({
+      type: 'object',
+      properties: { ok: { type: 'boolean' } },
+    })
+  })
+
+  it('surfaces format: "date-time" for a schema that carries it — the exact shape #112 was about', () => {
+    const schema = z.object({ at: z.iso.datetime({ local: true }) })
+
+    expect(toolOutputJsonSchema(schema).properties).toMatchObject({ at: { format: 'date-time' } })
+  })
+})

--- a/packages/mcp/src/core/tool/json-schema.ts
+++ b/packages/mcp/src/core/tool/json-schema.ts
@@ -1,0 +1,14 @@
+import type { z } from 'zod'
+
+/**
+ * The JSON Schema a client actually receives for a tool's `outputSchema`,
+ * built the same way `@modelcontextprotocol/server` builds it when
+ * registering a tool (`~standard.jsonSchema.output({ target: 'draft-2020-12' })`,
+ * zod's Standard Schema JSON conversion — see `zod/v4/core/standard-schema.d.ts`).
+ * Exists so tests can assert against what the wire protocol actually carries,
+ * not just what `.safeParse()` accepts — see `output-schema-regression.test.ts`
+ * and github.com/Ilmar7786/marzban-sdk#112.
+ */
+export function toolOutputJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  return schema['~standard'].jsonSchema.output({ target: 'draft-2020-12' })
+}

--- a/packages/mcp/src/modules/subscription/subscription.schemas.test.ts
+++ b/packages/mcp/src/modules/subscription/subscription.schemas.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { subscriptionInfoOutputSchema, usersRevokeSubscriptionOutputSchema } from './subscription.schemas'
+
+// #112: Marzban returns created_at (and sub_updated_at/online_at/on_hold_timeout)
+// without a UTC offset — both output schemas here wrap a full user response and
+// must accept that shape. See users.schemas.test.ts for the same check on the
+// users module, and output-schema-regression.test.ts for the JSON-Schema-level
+// guarantee that no `format` claim reaches the client in the first place.
+const offsetLessUser = {
+  proxies: {},
+  username: 'alice',
+  status: 'active' as const,
+  used_traffic: 0,
+  created_at: '2026-09-02T14:00:57.764445',
+  sub_updated_at: null,
+  online_at: '2026-09-02T14:00:57.764445',
+  on_hold_timeout: null,
+}
+
+describe("output schemas accept Marzban's real, offset-less datetimes", () => {
+  it('subscriptionInfoOutputSchema', () => {
+    expect(subscriptionInfoOutputSchema.safeParse(offsetLessUser).success).toBe(true)
+  })
+
+  it('usersRevokeSubscriptionOutputSchema', () => {
+    expect(usersRevokeSubscriptionOutputSchema.safeParse(offsetLessUser).success).toBe(true)
+  })
+})

--- a/packages/mcp/src/modules/subscription/subscription.schemas.ts
+++ b/packages/mcp/src/modules/subscription/subscription.schemas.ts
@@ -1,7 +1,11 @@
-import { subscriptionUserResponseSchema, userResponseSchema } from 'marzban-sdk'
 import { z } from 'zod'
 
-import { confirmTokenSchema, usernameSchema } from '@/shared/schemas'
+import {
+  confirmTokenSchema,
+  mcpSubscriptionUserResponseSchema,
+  mcpUserResponseSchema,
+  usernameSchema,
+} from '@/shared/schemas'
 
 export const subscriptionInfoInputSchema = z.object({
   subscriptionToken: z
@@ -12,11 +16,11 @@ export const subscriptionInfoInputSchema = z.object({
     ),
 })
 
-export const subscriptionInfoOutputSchema = subscriptionUserResponseSchema
+export const subscriptionInfoOutputSchema = mcpSubscriptionUserResponseSchema
 
 export const usersRevokeSubscriptionInputSchema = z.object({
   username: usernameSchema,
   confirmToken: confirmTokenSchema,
 })
 
-export const usersRevokeSubscriptionOutputSchema = userResponseSchema
+export const usersRevokeSubscriptionOutputSchema = mcpUserResponseSchema

--- a/packages/mcp/src/modules/subscription/subscription.views.test.ts
+++ b/packages/mcp/src/modules/subscription/subscription.views.test.ts
@@ -13,7 +13,7 @@ function makeSubscriptionUser(overrides: Partial<SubscriptionUserResponse> = {})
     username: 'alice',
     status: 'active',
     used_traffic: 0,
-    created_at: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00', // Marzban's real wire format — no offset, see #112
     ...overrides,
   }
 }

--- a/packages/mcp/src/modules/users/users.helpers.test.ts
+++ b/packages/mcp/src/modules/users/users.helpers.test.ts
@@ -11,7 +11,7 @@ function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
     username: 'alice',
     status: 'active',
     used_traffic: 0,
-    created_at: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00', // Marzban's real wire format — no offset, see #112
     ...overrides,
   }
 }

--- a/packages/mcp/src/modules/users/users.schemas.test.ts
+++ b/packages/mcp/src/modules/users/users.schemas.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { usersExtendInputSchema, usersResetTrafficInputSchema } from './users.schemas'
+import {
+  usersActivateOutputSchema,
+  usersCreateOutputSchema,
+  usersDeactivateOutputSchema,
+  usersExtendInputSchema,
+  usersExtendOutputSchema,
+  usersGetOutputSchema,
+  usersHoldOutputSchema,
+  usersListOutputSchema,
+  usersResetTrafficInputSchema,
+  usersUpdateOutputSchema,
+} from './users.schemas'
 
 describe('usersExtendInputSchema', () => {
   it('accepts addDuration alone', () => {
@@ -37,5 +48,52 @@ describe('usersResetTrafficInputSchema', () => {
     const result = usersResetTrafficInputSchema.safeParse({})
     expect(result.success).toBe(false)
     expect(result.error?.issues[0].message).toContain('Provide either username, or all=true')
+  })
+})
+
+// #112: Marzban returns created_at (and sub_updated_at/online_at/on_hold_timeout)
+// without a UTC offset. Every output schema wrapping a UserResponse must accept
+// that shape — this is the parsing half of the fix; output-schema-regression.test.ts
+// covers the other half (no `format` claim reaches the client in the first place).
+const offsetLessUser = {
+  proxies: {},
+  username: 'alice',
+  status: 'active' as const,
+  used_traffic: 0,
+  created_at: '2026-09-02T14:00:57.764445',
+  sub_updated_at: null,
+  online_at: '2026-09-02T14:00:57.764445',
+  on_hold_timeout: null,
+}
+
+describe("output schemas accept Marzban's real, offset-less datetimes", () => {
+  it('usersCreateOutputSchema / usersUpdateOutputSchema / usersActivateOutputSchema / usersDeactivateOutputSchema / usersHoldOutputSchema', () => {
+    for (const schema of [
+      usersCreateOutputSchema,
+      usersUpdateOutputSchema,
+      usersActivateOutputSchema,
+      usersDeactivateOutputSchema,
+      usersHoldOutputSchema,
+    ]) {
+      expect(schema.safeParse(offsetLessUser).success).toBe(true)
+    }
+  })
+
+  it('usersGetOutputSchema', () => {
+    const result = usersGetOutputSchema.safeParse({
+      user: offsetLessUser,
+      summary: { dataLeftBytes: null, usagePercent: null, daysLeft: null, isExpired: false },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('usersListOutputSchema', () => {
+    const result = usersListOutputSchema.safeParse({ users: [offsetLessUser], total: 1, note: '' })
+    expect(result.success).toBe(true)
+  })
+
+  it('usersExtendOutputSchema', () => {
+    const result = usersExtendOutputSchema.safeParse({ user: offsetLessUser, note: 'extended' })
+    expect(result.success).toBe(true)
   })
 })

--- a/packages/mcp/src/modules/users/users.schemas.ts
+++ b/packages/mcp/src/modules/users/users.schemas.ts
@@ -1,9 +1,10 @@
-import { userResponseSchema, userUsageResponseSchema } from 'marzban-sdk'
+import { userUsageResponseSchema } from 'marzban-sdk'
 import { z } from 'zod'
 
 import {
   confirmTokenSchema,
   durationMsInputSchema,
+  mcpUserResponseSchema,
   sizeInputSchema,
   timestampInputSchema,
   usernameSchema,
@@ -35,7 +36,7 @@ export const usersListInputSchema = z.object({
 })
 
 export const usersListOutputSchema = z.object({
-  users: z.array(userResponseSchema),
+  users: z.array(mcpUserResponseSchema),
   total: z.number(),
   note: z.string(),
 })
@@ -54,7 +55,7 @@ export const userSummarySchema = z.object({
 })
 
 export const usersGetOutputSchema = z.object({
-  user: userResponseSchema,
+  user: mcpUserResponseSchema,
   summary: userSummarySchema,
 })
 
@@ -85,7 +86,7 @@ export const usersCreateInputSchema = z.object({
     ),
 })
 
-export const usersCreateOutputSchema = userResponseSchema
+export const usersCreateOutputSchema = mcpUserResponseSchema
 
 // --- users_update ----------------------------------------------------------
 
@@ -99,15 +100,15 @@ export const usersUpdateInputSchema = z.object({
   inbounds: inboundsInputSchema,
 })
 
-export const usersUpdateOutputSchema = userResponseSchema
+export const usersUpdateOutputSchema = mcpUserResponseSchema
 
 // --- users_activate / deactivate / hold -------------------------------------
 
 export const usersActivateInputSchema = z.object({ username: usernameSchema })
-export const usersActivateOutputSchema = userResponseSchema
+export const usersActivateOutputSchema = mcpUserResponseSchema
 
 export const usersDeactivateInputSchema = z.object({ username: usernameSchema })
-export const usersDeactivateOutputSchema = userResponseSchema
+export const usersDeactivateOutputSchema = mcpUserResponseSchema
 
 export const usersHoldInputSchema = z.object({
   username: usernameSchema,
@@ -118,7 +119,7 @@ export const usersHoldInputSchema = z.object({
     .optional()
     .describe('Seconds the user may stay on_hold before expiring, counted from their first connection.'),
 })
-export const usersHoldOutputSchema = userResponseSchema
+export const usersHoldOutputSchema = mcpUserResponseSchema
 
 // --- users_extend ----------------------------------------------------------
 
@@ -138,7 +139,7 @@ export const usersExtendInputSchema = z
   })
 
 export const usersExtendOutputSchema = z.object({
-  user: userResponseSchema,
+  user: mcpUserResponseSchema,
   note: z.string(),
 })
 

--- a/packages/mcp/src/modules/users/users.tools.test.ts
+++ b/packages/mcp/src/modules/users/users.tools.test.ts
@@ -24,7 +24,7 @@ function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
     username: 'alice',
     status: 'active',
     used_traffic: 0,
-    created_at: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00', // Marzban's real wire format — no offset, see #112
     ...overrides,
   }
 }

--- a/packages/mcp/src/modules/users/users.views.test.ts
+++ b/packages/mcp/src/modules/users/users.views.test.ts
@@ -23,7 +23,7 @@ function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
     username: 'alice',
     status: 'active',
     used_traffic: 0,
-    created_at: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00',
     ...overrides,
   }
 }
@@ -62,7 +62,7 @@ describe('userView (single user)', () => {
 
   it('full row includes note/reset-strategy/created_at on top of the compact fields', () => {
     const row = userView.full!(makeUser({ note: 'vip', data_limit_reset_strategy: 'month' }), HIDE) as ViewRow
-    expect(row).toMatchObject({ note: 'vip', data_limit_reset_strategy: 'month', created_at: '2026-01-01T00:00:00Z' })
+    expect(row).toMatchObject({ note: 'vip', data_limit_reset_strategy: 'month', created_at: '2026-01-01T00:00:00' })
   })
 
   it('defaults reset strategy display to no_reset when unset', () => {

--- a/packages/mcp/src/output-schema-regression.test.ts
+++ b/packages/mcp/src/output-schema-regression.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { toolOutputJsonSchema } from './core/tool/json-schema'
+import { allTools } from './modules'
+
+// A tool's outputSchema becomes the JSON Schema a client validates
+// structuredContent against. `format` is the one JSON Schema keyword whose
+// enforcement level is entirely up to the client: a strict validator checks
+// it, a lenient one ignores it — and Marzban's own API doesn't back several
+// of the formats zod is happy to claim (e.g. `z.iso.datetime({ local: true })`
+// still emits `format: "date-time"`, which RFC 3339 says requires a UTC
+// offset Marzban doesn't send — github.com/Ilmar7786/marzban-sdk#112).
+//
+// Rather than re-litigate this one field, no tool's outputSchema may emit
+// `format` at all: it's a claim about the wire format that this codebase has
+// no way to verify holds for every value Marzban can return, on any field,
+// now or after a future tool is added. A schema fixed by removing `format`
+// still validates every real response — it just stops promising something
+// nobody checked. A deliberate, verified exception is fine; add it in its
+// own commit with a comment explaining what makes that field's format claim
+// actually safe, rather than folding it into an unrelated change.
+function findFormatPaths(node: unknown, path: string): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, index) => findFormatPaths(item, `${path}[${index}]`))
+  }
+  if (node === null || typeof node !== 'object') return []
+
+  const found: string[] = []
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'format') found.push(`${path}.format`)
+    found.push(...findFormatPaths(value, `${path}.${key}`))
+  }
+  return found
+}
+
+describe('output schema regression: no tool outputSchema claims a JSON Schema format', () => {
+  it.each(allTools.map(tool => [tool.name, tool] as const))('%s', (_name, tool) => {
+    const jsonSchema = toolOutputJsonSchema(tool.outputSchema)
+
+    expect(findFormatPaths(jsonSchema, tool.name)).toEqual([])
+  })
+})

--- a/packages/mcp/src/shared/schemas.ts
+++ b/packages/mcp/src/shared/schemas.ts
@@ -1,4 +1,10 @@
-import { parseSize } from 'marzban-sdk'
+import {
+  parseSize,
+  type SubscriptionUserResponse,
+  subscriptionUserResponseSchema,
+  type UserResponse,
+  userResponseSchema,
+} from 'marzban-sdk'
 import { z } from 'zod'
 
 import { isDurationString, parseDurationMs } from './duration'
@@ -57,3 +63,46 @@ export const timestampInputSchema = z.union([z.string(), z.number().int().nonneg
   }
   return Math.floor(asDate.getTime() / 1000)
 })
+
+// --- output-side: SDK response schemas made wire-honest ------------------
+
+/**
+ * `UserResponse`/`SubscriptionUserResponse`'s four datetime fields, as the
+ * MCP layer should declare them in an `outputSchema` — plain `z.string()`,
+ * deliberately NOT the SDK's `z.iso.datetime({ local: true })`.
+ *
+ * `local: true` is the *correct* choice on the SDK side (`kubb.config.ts`):
+ * Marzban returns these fields without a UTC offset —
+ * `created_at: "2026-09-02T14:00:57.764445"`, no `Z`, no `+00:00` — and the
+ * SDK has to parse that. But converting `z.iso.datetime({ local: true })` to
+ * JSON Schema still emits `format: "date-time"` (RFC 3339, offset required)
+ * alongside a `pattern` that *does* allow the missing offset — and a strict
+ * client validates `structuredContent` against `format`, not `pattern`. It
+ * rejects Marzban's real response even though the call succeeded
+ * (github.com/Ilmar7786/marzban-sdk#112). Plain `z.string()` makes no format
+ * claim the wire format can't back up.
+ *
+ * Never reuse an SDK response schema wholesale as an MCP `outputSchema`
+ * without overriding these — see `mcpUserResponseSchema`/
+ * `mcpSubscriptionUserResponseSchema` below, and the "no `format` keyword in
+ * any outputSchema" invariant in `output-schema-regression.test.ts`.
+ */
+const WIRE_DATETIME_FIELDS = {
+  created_at: z.string(),
+  sub_updated_at: z.string().nullable().optional(),
+  online_at: z.string().nullable().optional(),
+  on_hold_timeout: z.string().nullable().optional(),
+}
+
+// kubb types these exports as opaque `z.ZodType<X>` (see e.g.
+// packages/sdk/src/gen/schemas/userResponseSchema.ts) even though they're
+// `ZodObject`s at runtime — the cast below is what makes `.extend()`
+// reachable. Every other field (present now or added later) is inherited
+// from the SDK schema unchanged; only the four above are overridden.
+export const mcpUserResponseSchema = (userResponseSchema as unknown as z.ZodObject<z.ZodRawShape>).extend(
+  WIRE_DATETIME_FIELDS
+) as unknown as z.ZodType<UserResponse>
+
+export const mcpSubscriptionUserResponseSchema = (
+  subscriptionUserResponseSchema as unknown as z.ZodObject<z.ZodRawShape>
+).extend(WIRE_DATETIME_FIELDS) as unknown as z.ZodType<SubscriptionUserResponse>

--- a/packages/mcp/test/integration/smoke.integration.test.ts
+++ b/packages/mcp/test/integration/smoke.integration.test.ts
@@ -1,15 +1,28 @@
 import { randomUUID } from 'node:crypto'
 
 import type { ServerContext } from '@modelcontextprotocol/server'
+import Ajv2020 from 'ajv/dist/2020'
+import addFormats from 'ajv-formats'
 import { isHttpError } from 'marzban-sdk'
 import { afterAll, describe, expect, it } from 'vitest'
 
 import { createConfirmFn } from '../../src/core/confirm'
-import type { ToolContext } from '../../src/core/tool'
+import { type ToolContext, toolOutputJsonSchema } from '../../src/core/tool'
 import { nodesListTool } from '../../src/modules/nodes/nodes.tools'
-import { usersDeleteTool, usersExtendTool } from '../../src/modules/users/users.tools'
+import { usersCreateTool, usersDeleteTool, usersExtendTool } from '../../src/modules/users/users.tools'
 import { createTestToolContext } from './helpers/client'
 import { freshConnectionConfig, removeUserTolerantly } from './helpers/quirks'
+
+// Same validator shape a strict MCP client applies to structuredContent: a
+// real ajv instance with format assertions ON, checking the exact JSON
+// Schema @modelcontextprotocol/server derives from a tool's outputSchema
+// (see src/core/tool/json-schema.ts). A zod .safeParse() can't reproduce
+// this — it's oblivious to the `format` keyword entirely, which is exactly
+// how #112 shipped unnoticed. `strict: false` because the concern here is
+// format *assertion*, not ajv's opinions on schema-authoring style — kubb's
+// generated schemas aren't written for ajv's strict mode and that's a
+// separate axis from the bug this test exists to catch.
+const strictClientValidator = addFormats(new Ajv2020({ strict: false }))
 
 const SHADOWSOCKS_PROXY = { shadowsocks: {} }
 const fakeServerCtx = {} as ServerContext
@@ -89,5 +102,27 @@ describe('MCP tool smoke tests (real SDK, real panel)', () => {
     }
 
     await expect(ctx.sdk.user.getUser(username, freshConnectionConfig())).rejects.toMatchObject({ status: 404 })
+  })
+
+  it('marzban_users_create: structuredContent validates under a strict client, even though Marzban returns created_at without a UTC offset (#112)', async () => {
+    ctx = await createTestToolContext()
+    const username = uniqueUsername('datetime')
+
+    try {
+      const result = await usersCreateTool.handler({ username, status: 'active', proxies: SHADOWSOCKS_PROXY }, ctx)
+
+      // Guards the guard: if Marzban ever starts sending an offset, this
+      // assertion fails first — signaling the check below stopped exercising
+      // the thing #112 was actually about.
+      expect(result.created_at).not.toMatch(/(Z|[+-]\d{2}:\d{2})$/)
+
+      const validate = strictClientValidator.compile(toolOutputJsonSchema(usersCreateTool.outputSchema))
+      const valid = validate(result)
+
+      expect(validate.errors ?? []).toEqual([])
+      expect(valid).toBe(true)
+    } finally {
+      await removeUserTolerantly(ctx.sdk, username)
+    }
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.9.0)
@@ -7451,6 +7457,10 @@ snapshots:
   ajv-formats@3.0.1(@redocly/ajv@8.18.1):
     optionalDependencies:
       ajv: '@redocly/ajv@8.18.1'
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #112.

- Marzban returns `created_at`/`sub_updated_at`/`online_at`/`on_hold_timeout` without a UTC offset. MCP reused the SDK's parsing-oriented `userResponseSchema`/`subscriptionUserResponseSchema` wholesale as tool `outputSchema`s, and `z.iso.datetime({ local: true })` still lowers to JSON Schema `format: "date-time"` — a strict client (Claude Desktop) rejected `structuredContent` on every user-returning tool even though the call succeeded.
- Fixed at the MCP boundary only: `shared/schemas.ts` now exports `mcpUserResponseSchema`/`mcpSubscriptionUserResponseSchema`, the SDK schema with those four fields overridden to plain `z.string()` via `.extend()`. SDK/`kubb.config.ts` untouched — `local: true` stays correct there for parsing. Covers all 10 affected output schemas (the 8 originally listed in the issue, plus `users_extend` and `users_revoke_subscription`, found while auditing every SDK-schema reuse).
- Added `output-schema-regression.test.ts`: iterates every registered tool and asserts its JSON Schema (built the same way `@modelcontextprotocol/server` builds it) never emits a `format` keyword at all — broader than the four fields found, so a future tool reusing an SDK schema unsafely fails a test instead of shipping.
- Added a real `ajv`/`ajv-formats` check in `smoke.integration.test.ts` against the live local panel — reproduces exactly what a strict client does, since `.safeParse()` structurally can't see this class of bug. Verified this test fails with the pre-fix schema (reproducing the reported `must match format "date-time"` error byte-for-byte) and passes after.
- `packages/mcp/ARCHITECTURE.md`'s "add a tool" step is corrected (it previously told authors to reuse SDK schemas without this caveat), `docs/marzban-quirks.md` documents the panel behavior, and `docs/adr/0018-mcp-output-schemas-no-format-keyword.md` records the invariant and why a narrower fix was rejected.

## Test plan

- [x] `pnpm --filter marzban-mcp test:coverage` — 410 tests, 100% coverage
- [x] `pnpm --filter marzban-mcp test:integration` — 6 tests against local panel, including the new ajv check
- [x] Confirmed the new integration test fails against the pre-fix schema and passes after (manual revert/restore)
- [x] `pnpm lint && pnpm types:check && pnpm test` clean across the whole monorepo
- [x] Manually inspected the emitted JSON Schema for `marzban_users_create` — no `format` anywhere