### PR TITLE
fix(mcp): correct proxies description for marzban_users_create

### DIFF
--- a/packages/mcp/src/modules/users/users.schemas.ts
+++ b/packages/mcp/src/modules/users/users.schemas.ts
@@ -16,7 +16,7 @@ const proxiesInputSchema = z
   .record(z.string(), z.record(z.string(), z.unknown()))
   .optional()
   .describe(
-    'Protocol name -> settings, e.g. {"vless": {"id": "<uuid>"}}. Omit to leave unchanged (update) or use server defaults (create).'
+    'Protocol name -> settings, e.g. {"vless": {"id": "<uuid>"}} or {"shadowsocks": {}} to auto-generate credentials. Omit to leave unchanged on update. On create there is no server default — omitting this (without templateId) errors; provide at least one protocol with a matching inbound configured on the panel.'
   )
 
 const inboundsInputSchema = z


### PR DESCRIPTION
## Summary

`proxiesInputSchema`'s description claimed omitting `proxies` on create falls back to "server defaults". Marzban has no such default: omitting it entirely 500s, and an empty object 422s (`Each user needs at least one proxy`). Confirmed against the local panel:

- no `proxies` key → `500 Internal Server Error`
- `proxies: {}` → `422 {"detail":{"proxies":"Value error, Each user needs at least one proxy"}}`

Found by running `marzban_users_create` through a real Claude Desktop session (manual pass over every tool/prompt, local build + local panel): the model trusted the description, tried creating a user without/with empty `proxies`, and hit the error on every retry. Description now says create has no default, requires at least one protocol with a matching inbound, and shows a working minimal example (`{"shadowsocks": {}}`, panel auto-fills credentials).

## Test plan

- [x] `pnpm --filter marzban-mcp types:check && pnpm --filter marzban-mcp lint` — clean
- [x] Rebuilt `packages/mcp/dist`, confirmed via a raw `tools/list` call that the corrected description reaches the wire schema
- [x] Manually verified both failure modes (missing / empty `proxies`) directly against the local panel, and that `{"shadowsocks": {}}` succeeds