### PR TITLE
feat(mcp): stop a repeated destructive call from running twice

### DIFF
--- a/apps/docs/content/docs/mcp-server/overview.mdx
+++ b/apps/docs/content/docs/mcp-server/overview.mdx
@@ -17,6 +17,7 @@ It's a separate package from the SDK itself. If you're building your own integra
 - **3 prompts** that chain those tools into ready-made investigations (expiring subscriptions, node health, traffic reports).
 - **Profile-gated access** — a tool outside the active profile never appears in `tools/list` at all, not just hidden behind a hint.
 - **Every destructive call needs confirmation** — a first call only describes the consequences and returns a one-time token; nothing runs until a second, explicitly confirmed call repeats it. Confirming one call never authorizes a different target or a wider version of the same call.
+- **A retried destructive call doesn't run twice** — an identical repeat within 5 minutes replays the first call's recorded result instead of executing again, and a call whose outcome was never observed says so instead of guessing.
 - **Credentials only from environment variables** — never accepted as a tool argument, so a model can't redirect the server or leak them through a call.
 - **Credential-bearing fields masked by default** — `proxies`, `subscription_url`, and `links` stay hidden unless you opt in.
 

--- a/apps/docs/content/docs/mcp-server/security.mdx
+++ b/apps/docs/content/docs/mcp-server/security.mdx
@@ -66,11 +66,31 @@ The signing key lives only in the server process's memory — a restart invalida
 
 | Mode | Behavior | Best for |
 |---|---|---|
-| `auto` (default) | Confirm once per tool name *and* exact arguments; a repeat of that same call proceeds without re-asking, but only within a 5-minute window | Interactive use — a genuine retry (a timeout, a reconnect) doesn't need re-confirming, but nothing broader is ever inferred from it |
+| `auto` (default) | Confirm once per tool name *and* exact arguments; a repeat of that same call proceeds without re-asking, but only within a 5-minute window | Interactive use — a genuine retry (a timeout, a reconnect) isn't re-confirmed, and isn't re-executed either (see below), but nothing broader is ever inferred from it |
 | `always` | Confirm every single call, with no memory of what was already confirmed | Shared or interactive environments where even one accumulated trust is undesirable |
 | `off` | Skip confirmation entirely, from the very first call | Fully automated, unattended environments only — there is no safety net once this is set |
 
 Trust in `auto` mode is granted per tool *and* per exact call arguments, not per tool name alone — confirming a delete for `alice` does **not** trust a delete for `bob`, and confirming `marzban_users_reset_traffic { username: "alice" }` does not trust the same tool called with `{ all: true }`. Each grant also expires after the same 5-minute window a confirm token uses, so a tool whose arguments never vary (`marzban_core_restart` always takes `{}`) can't turn one confirmation into unlimited free re-runs for the rest of the connection. Every call that proceeds on accumulated trust — rather than a freshly verified token — is logged at `info` level (the default `MARZBAN_MCP_LOG_LEVEL=warn` suppresses it — set it to `info` or lower to see these).
+
+### Repeated calls and unknown outcomes
+
+Confirmation decides whether a call may run. It doesn't decide whether a call has *already* run — and those come apart exactly when it matters. A client that times out waiting for a tool call re-issues it; without a second mechanism, that second call restarts the core again, or overwrites the config again, and nothing in the conversation reveals that it happened twice.
+
+So every destructive call is remembered for **5 minutes**, keyed by the tool name and the exact arguments (the `confirmToken` is deliberately left out of that key, so a retry carrying one still matches the original call). Three things can happen:
+
+| Situation | What you get |
+|---|---|
+| First call of its kind | It runs normally |
+| Identical repeat within 5 minutes | The **recorded result of the first call**, with a note saying so. Nothing is sent to the panel |
+| The first call's outcome was never observed — an unsafe request that got no answer at all | An explicit **unknown** result telling the model to check the current state with a read-only tool instead of guessing or retrying |
+
+The last row is the important one. When a request goes out and no response comes back, nobody can honestly say whether the panel applied it — a core restart is, after all, the request most likely to kill the connection carrying it. Saying "I don't know, go look" is the only safe answer: a model told "failed" retries, a model told "unknown" reads.
+
+This applies in every `MARZBAN_MCP_CONFIRM` mode, because it protects the panel rather than the prompt — in `off`, it's the only protection left. A **fresh** confirmation still runs the operation for real: if a human is asked again and says yes again, that's a deliberate second run, not a retry. An accidental retry can never look like one, because it re-sends the already-consumed token, which fails verification.
+
+<Callout type="info">
+  The memory lives in the server process only. Restarting the server clears it, exactly like the confirm-token signing key — a fresh process makes no claims about what a previous one did. Note also that in `auto` mode a deliberate immediate re-run of a tool that takes no arguments (`marzban_core_restart`) isn't possible: wait out the 5-minute window, or run with `MARZBAN_MCP_CONFIRM=always`.
+</Callout>
 
 ## Credential masking
 

--- a/apps/docs/src/config/landing/mcp-features.ts
+++ b/apps/docs/src/config/landing/mcp-features.ts
@@ -17,7 +17,7 @@ export const mcpFeatures: LandingFeature[] = [
   {
     icon: ShieldCheck,
     title: 'Confirmation on destructive actions',
-    desc: 'The first call only describes the consequences and returns a one-time token; nothing runs until a human-approved second call repeats it.',
+    desc: 'The first call only describes the consequences and returns a one-time token; nothing runs until a human-approved second call repeats it — and a call retried after a timeout replays its recorded result instead of running a second time.',
   },
   {
     icon: EyeOff,

--- a/docs/adr/0019-idempotency-for-destructive-tool-calls.md
+++ b/docs/adr/0019-idempotency-for-destructive-tool-calls.md
@@ -1,0 +1,114 @@
+# ADR-0019: Destructive tool calls are deduplicated, not just re-confirmed
+
+Status: Accepted
+Date: 2026-09-05
+
+## Context
+
+Two layers can replay the same irreversible operation for the same reason:
+nobody saw a response, so the caller guesses. The lower layer was closed by
+narrowing the SDK's `retryCondition` so an unsafe HTTP method is never
+re-sent (github.com/Ilmar7786/marzban-sdk#75). The upper layer was still
+open: an MCP client that times out waiting for `tools/call` re-issues the
+call, and `core/tool/registry.ts` ran `tool.handler` for every call it was
+handed. For `marzban_core_restart` that is a second restart; for
+`marzban_config_update` a second overwrite
+(github.com/Ilmar7786/marzban-sdk#76).
+
+ADR-0013 made `confirm: 'auto'` trust a call rather than a tool, so a repeat
+with identical arguments proceeds without re-asking. That is the right
+behavior for a prompt — an honest retry should not pester a human twice —
+but it is precisely what let the retry reach the panel a second time. The
+confirmation gate answers "may this run?"; nothing answered "has this
+already run?".
+
+## Decision
+
+A dedup store for `scope: 'destructive'` tools, as its own pipeline stage in
+`core/tool/registry.ts` after the confirmation gate, backed by
+`core/idempotency/`.
+
+- **Key**: `callKey(tool.name, args)` — moved out of `core/confirm/confirm.ts`
+  into `core/confirm/canonical.ts` so the trust cache and the dedup store
+  share one definition of "the same call", as ADR-0013 anticipated.
+  `confirmToken` is excluded from the hash: it carries a fresh `jti` per
+  mint, so including it would make every retry a different key and defeat the
+  mechanism.
+- **Order**: confirm first, dedup second. The key ignores `confirmToken`, so
+  a caller presenting no token hashes to the same key as the confirmed
+  original; deduping first would hand that caller the recorded result — for
+  `marzban_config_update`, the entire previous core config in `backup` —
+  past a gate ADR-0013 had just tightened.
+- **Records the handler's plain data, not the finished `CallToolResult`.**
+  The recording boundary then wraps only the mutation, so a failure in
+  rendering cannot lose the fact that a delete happened. A replay re-renders
+  under the current output settings and gets a leading notice block saying it
+  is a recording; `structuredContent` stays exactly as recorded, which is
+  what the tool's `outputSchema` constrains. Reporting a replay as a fresh
+  execution would be a silent lie, the one failure mode a safety feature must
+  not have.
+- **Only an unanswered unsafe request is "unknown".** `core/idempotency/classify.ts`
+  treats every other failure as provably not applied: the panel answering
+  4xx/5xx means it refused; a failure with no method never left the client; a
+  failure on a safe method is the read that destructive handlers do before
+  they write (`getCoreConfig`, `getHosts`). Only those stay retryable. An
+  unanswered POST/DELETE records an `unknown` outcome, and a later identical
+  call is told to verify state with a read tool rather than guess.
+- **A freshly verified confirm token overrides a record.** `ConfirmDecision`
+  now reports why a call was allowed, and `reason: 'token'` bypasses the
+  store. Without it, `confirm: 'always'` — where reaching the handler at all
+  requires a human to re-approve — would answer a deliberate second restart
+  with a four-minute-old result. An accidental retry cannot reach this path:
+  it re-sends the consumed token, which fails verification as `reused`.
+- **Concurrent duplicates share one execution** rather than being answered
+  `unknown`; the exact answer is seconds away, and both callers get it.
+- **TTL is 300 seconds, as its own constant**, not an import of
+  `CONFIRM_TOKEN_TTL_SECONDS` and not an env var. The two windows are equal
+  today by coincidence of judgment — a confirmation window is about how
+  recently a human agreed, this one about how long a client might still be
+  retrying — and coupling them would let a change to one silently move the
+  other. The store is capped at 256 entries, evicting oldest-first.
+- **Process memory only.** A restarted server has no record of what a
+  previous run executed and must not pretend otherwise — the same policy the
+  confirm signing key follows.
+
+Rejected: making the store the confirmation gate's job. `ConfirmDecision`
+carries a verdict, not a result; widening it to also produce rendered data
+would collapse the split that keeps handlers returning plain data. It would
+also inherit the gate's early return on `confirm: 'off'`, disabling dedup in
+the one mode that has no other protection.
+
+Rejected: a shorter TTL for `unknown` records than for successful ones. It
+expires the dangerous branch first.
+
+## Consequences
+
+- In `off`, dedup is the only thing standing between a retry and a second
+  execution. In `auto`, the trust cache makes the retry admissible and dedup
+  makes it a no-op — both are needed, neither subsumes the other. In
+  `always`, the gate already blocks a bare repeat, so dedup mostly records.
+- A deliberate immediate re-run of an argument-less destructive tool
+  (`marzban_core_restart` always takes `{}`) is not expressible in `auto`:
+  the trust cache is consulted before the token, so even a fresh token
+  reports `trusted` and the call is replayed. Waiting out the window, or
+  running in `always`, is the way to force a second run. The replay notice
+  makes this visible rather than silent. Reordering the gate to check a
+  presented token first would fix it and is left as separate work.
+- A panel that is merely unreachable poisons a key with `unknown` for the
+  window: `ECONNREFUSED` is provably not applied, but it is indistinguishable
+  from a timeout on an in-flight DELETE, because the transport code sits in
+  `HttpError.details` with no public accessor. The cost is a needless "verify
+  the state" answer, never a wrong one. A `transportCode` getter on
+  `HttpError` would narrow it — tracked separately, since it is an SDK
+  change.
+- Recorded data can contain masked-by-view credentials (`proxies`,
+  `subscription_url`) in `structuredContent`, held for up to five minutes.
+  Not a new class of exposure — `render` already returns raw data on every
+  call — but the retention window is new.
+- The store is per server instance and the transport is stdio, so one client
+  per process gives session isolation for free. An HTTP transport would have
+  to fold `sessionId` into the key, or keep a store per session.
+- The single-flight branch assumes no `AbortSignal` reaches the SDK: handlers
+  receive only `ToolContext`. If `serverCtx.mcpReq.signal` is ever plumbed
+  through, one caller's cancellation would abort a shared operation, and the
+  abort would have to be keyed to "every waiter has gone".

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,3 +59,4 @@ What this enables, what it costs.
 | [0016](./0016-ws-stream-lifecycle-and-reconnect.md)                  | WebSocket stream lifecycle and reconnect policy                     |
 | [0017](./0017-ws-public-stream-surface.md)                           | WS stream public surface — replay, reconnect, and header auth       |
 | [0018](./0018-mcp-output-schemas-no-format-keyword.md)               | MCP `outputSchema`s never emit a JSON Schema `format` keyword       |
+| [0019](./0019-idempotency-for-destructive-tool-calls.md)             | Destructive tool calls are deduplicated, not just re-confirmed      |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,10 @@ other.
 - **Consumers can grow the SDK's public API, but only by widening the barrel.**
   When `marzban-mcp` needed logger types, error codes, or `redactSecrets`, those
   were added as named exports to `index.ts` — not read off SDK internals by
-  duck-typing. The one exception (`HttpError.details` read via optional
-  chaining in MCP's error mapper) is tracked as debt, not the pattern to copy.
+  duck-typing. When `marzban-mcp` needed to know whether a failed request had
+  been answered at all, it used `HttpError`'s public `status`/`method`
+  getters; anything those getters don't expose (the transport-level error
+  code, say) is a gap to close in the SDK, not to reach past.
 - **No package depends on another consumer package.** If `mcp` and `cli` ever
   need to share logic, it belongs in the SDK, not in a new cross-dependency.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -60,8 +60,12 @@ pnpm --filter marzban-sdk test:coverage
   ADR-0018 and the `output-schema-regression.test.ts` unit test for the rest
   of that guard). `smoke.integration.test.ts` covers that at the smallest
   scope: one passthrough tool, one with MCP-only logic, one destructive tool
-  through the confirm-flow, one output validated against a real ajv instance
-  the way a strict MCP client validates `structuredContent`.
+  through the confirm-flow, one destructive tool repeated to prove the dedup
+  store replays instead of running it twice (#76 — driven through
+  `registerTools` via `helpers/pipeline.ts`, since confirmation and dedup are
+  registry stages a direct `tool.handler` call would skip), one output
+  validated against a real ajv instance the way a strict MCP client validates
+  `structuredContent`.
   `users-lifecycle.integration.test.ts` covers the full
   path GitHub issue #65's Definition of Done asked for — create → extend →
   deactivate → activate → usage → delete through the actual MCP tools, plus

--- a/packages/mcp/ARCHITECTURE.md
+++ b/packages/mcp/ARCHITECTURE.md
@@ -20,19 +20,20 @@ and format responses to fit a model's context budget.
 
 ## Directory map
 
-| Directory            | Role                                                                                         |
-| -------------------- | -------------------------------------------------------------------------------------------- |
-| `src/index.ts`       | Binary entry point: load config, create the SDK client, create the server, serve over stdio. |
-| `src/server.ts`      | `createMarzbanMcpServer()` — builds the `McpServer` instance, registers tools and prompts.   |
-| `src/config/`        | Env-driven config schema, defaults, parsing.                                                 |
-| `src/core/tool/`     | Tool definition helper, registry (filtering, wiring), request context.                       |
-| `src/core/confirm/`  | Confirmation-token issuing and verification for destructive tools.                           |
-| `src/core/errors/`   | Maps SDK/tool errors to `CallToolResult`.                                                    |
-| `src/core/logger.ts` | stderr-only logger (see invariant below).                                                    |
-| `src/format/`        | Renders tool output: `view` → `text`/`table`/`json` → truncation.                            |
-| `src/modules/`       | Domain modules — one directory per area (users, config, nodes, system, subscription).        |
-| `src/prompts/`       | Pre-built MCP prompts that sequence existing tools for common investigations.                |
-| `src/shared/`        | Cross-module schemas and small utilities (pagination, duration parsing).                     |
+| Directory               | Role                                                                                         |
+| ----------------------- | -------------------------------------------------------------------------------------------- |
+| `src/index.ts`          | Binary entry point: load config, create the SDK client, create the server, serve over stdio. |
+| `src/server.ts`         | `createMarzbanMcpServer()` — builds the `McpServer` instance, registers tools and prompts.   |
+| `src/config/`           | Env-driven config schema, defaults, parsing.                                                 |
+| `src/core/tool/`        | Tool definition helper, registry (filtering, wiring), request context.                       |
+| `src/core/confirm/`     | Confirmation-token issuing and verification for destructive tools.                           |
+| `src/core/idempotency/` | Remembers destructive calls so a repeat replays instead of running again.                    |
+| `src/core/errors/`      | Maps SDK/tool errors to `CallToolResult`.                                                    |
+| `src/core/logger.ts`    | stderr-only logger (see invariant below).                                                    |
+| `src/format/`           | Renders tool output: `view` → `text`/`table`/`json` → truncation.                            |
+| `src/modules/`          | Domain modules — one directory per area (users, config, nodes, system, subscription).        |
+| `src/prompts/`          | Pre-built MCP prompts that sequence existing tools for common investigations.                |
+| `src/shared/`           | Cross-module schemas and small utilities (pagination, duration parsing).                     |
 
 ## Server setup
 
@@ -50,7 +51,7 @@ Every registered tool runs through the same wrapper, defined once in
 
 ```mermaid
 flowchart LR
-    A["selectTools()<br/>filtering"] --> B["confirm<br/>(destructive only)"] --> C["handler(args, ctx)"] --> D["render(data, view)"] --> E["error mapping"]
+    A["selectTools()<br/>filtering"] --> B["confirm<br/>(destructive only)"] --> C["dedup<br/>(destructive only)"] --> D["handler(args, ctx)"] --> E["render(data, view)"] --> F["error mapping"]
 ```
 
 - **Filtering** happens once at startup: profile scope first
@@ -66,6 +67,15 @@ flowchart LR
   `MARZBAN_MCP_CONFIRM` controls the mode: `off`, `auto` (confirm once per
   tool _and_ exact arguments, trusted for the same TTL as the token —
   `core/confirm/confirm.ts`'s `trustedCalls`), `always`.
+- **Dedup** applies to the same calls confirmation does, in every confirm
+  mode, and answers a different question: not "may this run?" but "has this
+  already run?". `core/idempotency/` remembers each destructive call by the
+  same `callKey` the trust cache uses, for five minutes; an identical repeat
+  replays the recorded data with a notice instead of reaching the SDK, and a
+  call whose outcome was never observed (an unsafe request that got no
+  response) reports `unknown` and steers the model to verify state. A freshly
+  verified token (`ConfirmDecision.reason === 'token'`) bypasses the record —
+  see ADR-0019.
 - **Handlers return plain data**, never a `CallToolResult` — rendering and
   error mapping are the pipeline's job, not the tool's.
 
@@ -234,13 +244,16 @@ To add a tool:
    [`docs/testing.md`](../../docs/testing.md)).
 
 `server.ts` and `core/tool/registry.ts` need no changes — filtering,
-annotations, confirmation, rendering, and error mapping apply automatically.
+annotations, confirmation, deduplication, rendering, and error mapping apply
+automatically.
 
 ## Known trade-offs
 
 - The tool list is documented by hand in three places (code, `README.md`,
   the docs site) with nothing checking they agree — see
   [`docs/architecture.md`](../../docs/architecture.md).
-- `core/errors/to-tool-error.ts` reads `HttpError.details.response.status`
-  directly rather than through a typed SDK accessor — the one place this
-  package relies on SDK internals instead of its public API.
+- `core/idempotency/classify.ts` can't tell "the connection was refused, so
+  nothing was applied" from "an in-flight write timed out", because the
+  transport-level error code has no public accessor on `HttpError`. It
+  errs toward `unknown`, so an unreachable panel produces a needless "verify
+  the state" answer for the length of the dedup window — see ADR-0019.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -63,6 +63,7 @@ and the tools below become available.
 - 🔒 **Env-only credentials** — the panel URL, username and password are never accepted as a tool argument, so a compromised or confused model can't redirect the server elsewhere.
 - 🎯 **Profile-gated tools** — a tool outside the active profile never appears in `tools/list` at all, not just hidden behind a hint.
 - ✅ **Confirmation on every destructive call** — the first call only describes the consequences and returns a one-time token; nothing runs until a human-approved second call repeats it, and confirming one call never authorizes a different target or a wider version of the same call.
+- 🔁 **A retried destructive call doesn't run twice** — an identical repeat within 5 minutes returns the recorded result of the first one instead of restarting the core again; a call whose outcome was never observed says so plainly rather than guessing.
 - 🙈 **Credentials masked by default** — `proxies`, `subscription_url` and `links` stay hidden unless you explicitly opt in.
 - 🧭 **21 tools, 3 prompts** — full user lifecycle, config, hosts, nodes, system stats and subscriptions, plus ready-made investigations that chain several tools together.
 - 🛠️ **Built on `marzban-sdk`** — the same auth, retry and reconnect behavior as the SDK itself, just exposed as MCP tools.
@@ -103,6 +104,15 @@ controls how often this is required: `auto` (default, once per tool _and_
 exact arguments, for 5 minutes — a different target or a wider call always
 needs its own confirmation), `always` (every call), or `off` (unattended
 environments only — no safety net once set).
+
+Confirmation decides whether a call may run; it doesn't decide whether it has
+already run. So each destructive call is also remembered for 5 minutes: an
+identical repeat — the kind a client sends after a timeout — returns the
+recorded result of the first one, with a note saying so, and never reaches
+the panel. When a request went out and no answer came back, the outcome is
+reported as unknown, with instructions to check the state with a read-only
+tool rather than retry. A fresh confirmation still runs the operation for
+real, and restarting the server clears the memory.
 
 ## Documentation
 

--- a/packages/mcp/src/core/confirm/canonical.test.ts
+++ b/packages/mcp/src/core/confirm/canonical.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { canonicalize, hashCallArgs } from './canonical'
+import { callKey, canonicalize, hashCallArgs } from './canonical'
 
 describe('canonicalize', () => {
   it('produces the same string regardless of key order', () => {
@@ -45,5 +45,31 @@ describe('hashCallArgs', () => {
 
   it('handles undefined args', () => {
     expect(hashCallArgs(undefined)).toBe(hashCallArgs({}))
+  })
+})
+
+describe('callKey', () => {
+  it('is the same for the same tool and arguments', () => {
+    expect(callKey('marzban_users_delete', { username: 'alice' })).toBe(
+      callKey('marzban_users_delete', { username: 'alice' })
+    )
+  })
+
+  it('ignores confirmToken, so a retry carrying one matches the original call', () => {
+    expect(callKey('marzban_users_delete', { username: 'alice', confirmToken: 'v1.abc' })).toBe(
+      callKey('marzban_users_delete', { username: 'alice' })
+    )
+  })
+
+  it('differs for the same arguments on a different tool', () => {
+    expect(callKey('marzban_users_delete', { username: 'alice' })).not.toBe(
+      callKey('marzban_users_reset_traffic', { username: 'alice' })
+    )
+  })
+
+  it('differs for different arguments on the same tool', () => {
+    expect(callKey('marzban_users_delete', { username: 'alice' })).not.toBe(
+      callKey('marzban_users_delete', { username: 'bob' })
+    )
   })
 })

--- a/packages/mcp/src/core/confirm/canonical.ts
+++ b/packages/mcp/src/core/confirm/canonical.ts
@@ -22,6 +22,16 @@ export function hashCallArgs(args: unknown): string {
   return createHash('sha256').update(canonicalize(rest)).digest('hex')
 }
 
+/**
+ * Identifies one specific call — this tool, these exact arguments. The single
+ * definition of "the same call" in this server: `confirm.ts` keys its `auto`
+ * trust cache by it, `core/idempotency` keys its dedup store by it, and both
+ * therefore agree on what counts as a repeat.
+ */
+export function callKey(toolName: string, args: unknown): string {
+  return `${toolName}:${hashCallArgs(args)}`
+}
+
 function sortKeysDeep(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortKeysDeep)
   if (value !== null && typeof value === 'object') {

--- a/packages/mcp/src/core/confirm/confirm.test.ts
+++ b/packages/mcp/src/core/confirm/confirm.test.ts
@@ -52,7 +52,7 @@ describe('createConfirmFn', () => {
     const tool = makeTool()
     const ctx = makeContext('off')
     const decision = await confirm({ tool, args: { username: 'alice' }, ctx, serverCtx: fakeServerCtx })
-    expect(decision).toEqual({ proceed: true })
+    expect(decision).toEqual({ proceed: true, reason: 'off' })
   })
 
   it('first call with no confirmToken asks for confirmation and includes a token in the message', async () => {
@@ -92,7 +92,9 @@ describe('createConfirmFn', () => {
     const token = first.message!.match(/confirmToken: "([^"]+)"/)![1]
 
     const second = await confirm({ tool, args: { ...args, confirmToken: token }, ctx, serverCtx: fakeServerCtx })
-    expect(second).toEqual({ proceed: true })
+    // `reason: 'token'` — a human approved this exact call moments ago, which
+    // is what lets core/idempotency run it rather than replay a record.
+    expect(second).toEqual({ proceed: true, reason: 'token' })
   })
 
   it('an invalid confirmToken is rejected, logged, and a fresh confirmation is requested', async () => {
@@ -147,7 +149,7 @@ describe('createConfirmFn', () => {
     await confirm({ tool, args: { ...args, confirmToken: token }, ctx, serverCtx: fakeServerCtx })
 
     const again = await confirm({ tool, args, ctx, serverCtx: fakeServerCtx })
-    expect(again).toEqual({ proceed: true })
+    expect(again).toEqual({ proceed: true, reason: 'trusted' })
     expect(ctx.logger.info).toHaveBeenCalledWith(expect.stringContaining('accumulated confirm trust'))
   })
 

--- a/packages/mcp/src/core/confirm/confirm.ts
+++ b/packages/mcp/src/core/confirm/confirm.ts
@@ -55,7 +55,7 @@ export function createConfirmFn(): ConfirmFn {
   }
 
   return async function confirm({ tool, args, ctx, serverCtx }): Promise<ConfirmDecision> {
-    if (ctx.config.confirm === 'off') return { proceed: true }
+    if (ctx.config.confirm === 'off') return { proceed: true, reason: 'off' }
 
     const key = callKey(tool.name, args)
 
@@ -64,7 +64,7 @@ export function createConfirmFn(): ConfirmFn {
       pruneExpired(now)
       if (trustedCalls.has(key)) {
         ctx.logger.info(`Proceeding on accumulated confirm trust for ${tool.name} (same call, still within TTL).`)
-        return { proceed: true }
+        return { proceed: true, reason: 'trusted' }
       }
     }
 
@@ -75,7 +75,12 @@ export function createConfirmFn(): ConfirmFn {
         if (ctx.config.confirm === 'auto') {
           trustedCalls.set(key, Date.now() + CONFIRM_TOKEN_TTL_SECONDS * 1000)
         }
-        return { proceed: true }
+        // `token` and not `trusted`: a single-use token verified just now is
+        // a human saying yes to this operation a moment ago, which is what
+        // lets `core/idempotency` run it again rather than replay a recorded
+        // outcome. An accidental retry never lands here — it re-sends the
+        // consumed token, which fails verification as `reused`.
+        return { proceed: true, reason: 'token' }
       }
       ctx.logger.warn(`Rejected confirmToken for ${tool.name}: ${result.reason}`)
     }

--- a/packages/mcp/src/core/confirm/confirm.ts
+++ b/packages/mcp/src/core/confirm/confirm.ts
@@ -1,5 +1,5 @@
 import type { ConfirmDecision, ConfirmFn } from '../tool'
-import { hashCallArgs } from './canonical'
+import { callKey } from './canonical'
 import { CONFIRM_TOKEN_TTL_SECONDS, createConfirmTokenCodec } from './token'
 
 function extractConfirmToken(args: unknown): string | undefined {
@@ -26,10 +26,6 @@ function buildConfirmationMessage(consequences: string, token: string): string {
     `Do not call this tool again until the user has explicitly said yes. Once they have, repeat the exact same call with confirmToken: "${token}" added.`,
     `The token is only valid for this tool and these exact arguments, and expires in ${Math.round(CONFIRM_TOKEN_TTL_SECONDS / 60)} minutes.`,
   ].join(' ')
-}
-
-function callKey(toolName: string, args: unknown): string {
-  return `${toolName}:${hashCallArgs(args)}`
 }
 
 /**

--- a/packages/mcp/src/core/confirm/index.ts
+++ b/packages/mcp/src/core/confirm/index.ts
@@ -1,3 +1,4 @@
+export { callKey, canonicalize, hashCallArgs } from './canonical'
 export { createConfirmFn } from './confirm'
 export {
   CONFIRM_TOKEN_TTL_SECONDS,

--- a/packages/mcp/src/core/idempotency/classify.test.ts
+++ b/packages/mcp/src/core/idempotency/classify.test.ts
@@ -1,0 +1,57 @@
+import { HttpError } from 'marzban-sdk'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { ToolError } from '../errors'
+import { classifyFailure } from './classify'
+
+describe('classifyFailure', () => {
+  it('treats a plain Error as not applied', () => {
+    expect(classifyFailure(new Error('boom'))).toBe('not-applied')
+  })
+
+  it('treats a non-Error throw as not applied', () => {
+    expect(classifyFailure('boom')).toBe('not-applied')
+  })
+
+  it('treats a schema validation failure as not applied', () => {
+    const parsed = z.object({ username: z.string() }).safeParse({})
+    expect(classifyFailure(parsed.error)).toBe('not-applied')
+  })
+
+  it('treats a ToolError as not applied', () => {
+    expect(classifyFailure(new ToolError('INTERNAL_ERROR', 'nope'))).toBe('not-applied')
+  })
+
+  it('treats a 4xx answer from the panel as not applied', () => {
+    expect(classifyFailure(new HttpError({ response: { status: 404 }, config: { method: 'delete' } }))).toBe(
+      'not-applied'
+    )
+  })
+
+  it('treats a 5xx answer from the panel as not applied — the panel answered, it just refused', () => {
+    expect(classifyFailure(new HttpError({ response: { status: 500 }, config: { method: 'post' } }))).toBe(
+      'not-applied'
+    )
+  })
+
+  it('treats a failure with no request at all as not applied', () => {
+    expect(classifyFailure(new HttpError('No access token after re-authentication'))).toBe('not-applied')
+  })
+
+  it('treats a non-string method as no method at all', () => {
+    expect(classifyFailure(new HttpError({ config: { method: 42 } }))).toBe('not-applied')
+  })
+
+  it('treats an unanswered read as not applied — the write never started', () => {
+    expect(classifyFailure(new HttpError({ config: { method: 'get' } }))).toBe('not-applied')
+  })
+
+  it('treats an unanswered POST as unknown', () => {
+    expect(classifyFailure(new HttpError({ config: { method: 'post' } }))).toBe('unknown')
+  })
+
+  it('treats an unanswered DELETE as unknown', () => {
+    expect(classifyFailure(new HttpError({ config: { method: 'delete' } }))).toBe('unknown')
+  })
+})

--- a/packages/mcp/src/core/idempotency/classify.ts
+++ b/packages/mcp/src/core/idempotency/classify.ts
@@ -1,0 +1,49 @@
+import { isHttpError } from 'marzban-sdk'
+
+/**
+ * RFC 9110 safe methods. Hardcoded rather than imported: the SDK's own
+ * `SAFE_HTTP_METHODS` lives in `core/http`, which is not part of its public
+ * barrel, and reaching past the barrel is forbidden (docs/architecture.md).
+ */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+/** Whether a failed call could have changed anything on the panel. */
+export type Applicability = 'not-applied' | 'unknown'
+
+/**
+ * Decides whether a thrown error leaves the panel provably untouched, or
+ * leaves its state genuinely unknown.
+ *
+ * This is the whole reason the dedup store can be safe: a call that provably
+ * did nothing must stay retryable, while a call whose outcome nobody observed
+ * must never be retried blindly. Only one shape means "unknown" — an unsafe
+ * HTTP method that was dispatched and never answered.
+ *
+ * Known limitation: `ECONNREFUSED`/`ENOTFOUND` (nothing ever left the host, so
+ * provably not applied) land in the `unknown` bucket too, because the
+ * transport-level code sits in `HttpError.details` with no public accessor.
+ * The cost is a needless "verify state" answer while a panel is unreachable,
+ * bounded by the store's TTL — never a wrong answer. Narrowing it needs a
+ * small SDK addition (a `transportCode` getter on `HttpError`), tracked
+ * separately.
+ */
+export function classifyFailure(error: unknown): Applicability {
+  // A ZodError, ToolError, ConfigurationError or AuthError never represents a
+  // dispatched-but-unanswered mutation.
+  if (!isHttpError(error)) return 'not-applied'
+
+  // The panel answered, with a 4xx or 5xx: it rejected the request.
+  if (error.status !== undefined) return 'not-applied'
+
+  // No method at all means the failure happened before a request was built.
+  const method = error.method
+  if (method === undefined) return 'not-applied'
+
+  // The request that failed was a read. Destructive handlers read before they
+  // write (`config_update` calls `getCoreConfig` first, `hosts_update` calls
+  // `getHosts`), so a failure here is a failure of the read, not the write.
+  // `HttpError.method` is documented to come back uppercased.
+  if (SAFE_METHODS.has(method)) return 'not-applied'
+
+  return 'unknown'
+}

--- a/packages/mcp/src/core/idempotency/idempotency.test.ts
+++ b/packages/mcp/src/core/idempotency/idempotency.test.ts
@@ -1,0 +1,237 @@
+import { HttpError } from 'marzban-sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import type { McpConfig } from '@/config'
+import type { View } from '@/format/views/types'
+
+import { defineTool, type ToolContext, type ToolDefinition } from '../tool'
+import { createDedupFn } from './idempotency'
+
+const echoView: View<{ echoed: string }> = { compact: data => [data] }
+
+function makeTool(name = 'marzban_test_destroy'): ToolDefinition<z.ZodType, z.ZodType> {
+  return defineTool({
+    name,
+    title: 'Test',
+    description: 'Test tool',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ echoed: z.string() }),
+    scope: 'destructive',
+    view: echoView,
+    handler: async () => ({ echoed: 'hi' }),
+  }) as unknown as ToolDefinition<z.ZodType, z.ZodType>
+}
+
+const ctx: ToolContext = {
+  sdk: {} as ToolContext['sdk'],
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  config: {} as McpConfig,
+}
+
+function call(overrides: { tool?: ToolDefinition<z.ZodType, z.ZodType>; args?: unknown; bypass?: boolean } = {}) {
+  return {
+    tool: overrides.tool ?? makeTool(),
+    args: overrides.args ?? { username: 'alice' },
+    ctx,
+    bypass: overrides.bypass ?? false,
+  }
+}
+
+/** An unanswered POST — the only error shape that leaves the panel's state unknown. */
+function unansweredWrite() {
+  return new HttpError({ config: { method: 'post' } })
+}
+
+describe('createDedupFn', () => {
+  it('runs the operation the first time it sees a call', async () => {
+    const dedup = createDedupFn()
+    const run = vi.fn(async () => ({ deleted: true }))
+
+    const outcome = await dedup({ ...call(), run })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(outcome).toEqual({ kind: 'executed', data: { deleted: true } })
+  })
+
+  it('replays the recorded result for an identical repeat, without running anything', async () => {
+    const dedup = createDedupFn()
+    const run = vi.fn(async () => ({ deleted: true }))
+
+    await dedup({ ...call(), run })
+    const outcome = await dedup({ ...call(), run })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(outcome.kind).toBe('replayed')
+    expect(outcome).toMatchObject({ data: { deleted: true } })
+  })
+
+  it('names the tool and says nothing was sent when it replays', async () => {
+    const dedup = createDedupFn()
+    const run = vi.fn(async () => ({ deleted: true }))
+
+    await dedup({ ...call(), run })
+    const outcome = await dedup({ ...call(), run })
+
+    expect(outcome.kind === 'replayed' && outcome.notice).toContain('marzban_test_destroy')
+    expect(outcome.kind === 'replayed' && outcome.notice).toContain('not a new execution')
+  })
+
+  it('matches a retry that carries a confirmToken to the original call', async () => {
+    const dedup = createDedupFn()
+    const run = vi.fn(async () => ({ deleted: true }))
+
+    await dedup({ ...call({ args: { username: 'alice' } }), run })
+    const outcome = await dedup({ ...call({ args: { username: 'alice', confirmToken: 'v1.abc' } }), run })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(outcome.kind).toBe('replayed')
+  })
+
+  it('runs again for different arguments', async () => {
+    const dedup = createDedupFn()
+    const run = vi.fn(async () => ({ deleted: true }))
+
+    await dedup({ ...call({ args: { username: 'alice' } }), run })
+    await dedup({ ...call({ args: { username: 'bob' } }), run })
+
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs again for the same arguments on a different tool', async () => {
+    const dedup = createDedupFn()
+    const run = vi.fn(async () => ({ deleted: true }))
+
+    await dedup({ ...call({ tool: makeTool('marzban_test_destroy') }), run })
+    await dedup({ ...call({ tool: makeTool('marzban_test_other') }), run })
+
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  describe('the record expires', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('runs again once the window has passed', async () => {
+      const dedup = createDedupFn()
+      const run = vi.fn(async () => ({ deleted: true }))
+
+      await dedup({ ...call(), run })
+      vi.advanceTimersByTime(301_000)
+      const outcome = await dedup({ ...call(), run })
+
+      expect(run).toHaveBeenCalledTimes(2)
+      expect(outcome.kind).toBe('executed')
+    })
+
+    it('accepts an interrupted call again once its window has passed', async () => {
+      const dedup = createDedupFn()
+      const run = vi.fn(async () => {
+        throw unansweredWrite()
+      })
+
+      await expect(dedup({ ...call(), run })).rejects.toThrow()
+      vi.advanceTimersByTime(301_000)
+      const outcome = await dedup({ ...call(), run: async () => ({ deleted: true }) })
+
+      expect(outcome.kind).toBe('executed')
+    })
+  })
+
+  describe('when the operation fails', () => {
+    it('reports a failure the panel answered as a plain error and stays retryable', async () => {
+      const dedup = createDedupFn()
+      const answered = new HttpError({ response: { status: 409 }, config: { method: 'post' } })
+      const run = vi.fn(async () => {
+        throw answered
+      })
+
+      await expect(dedup({ ...call(), run })).rejects.toBe(answered)
+      await expect(dedup({ ...call(), run })).rejects.toBe(answered)
+      expect(run).toHaveBeenCalledTimes(2)
+    })
+
+    it('gives the caller who hit the interruption the real error, not a steer', async () => {
+      const dedup = createDedupFn()
+      const interrupted = unansweredWrite()
+      const run = vi.fn(async () => {
+        throw interrupted
+      })
+
+      await expect(dedup({ ...call(), run })).rejects.toBe(interrupted)
+    })
+
+    it('tells the next identical call the outcome is unknown, and does not run it', async () => {
+      const dedup = createDedupFn()
+      const run = vi.fn(async () => {
+        throw unansweredWrite()
+      })
+
+      await expect(dedup({ ...call(), run })).rejects.toThrow()
+      const outcome = await dedup({ ...call(), run })
+
+      expect(run).toHaveBeenCalledTimes(1)
+      expect(outcome.kind).toBe('unknown')
+      expect(outcome.kind === 'unknown' && outcome.message).toContain('read-only tool')
+      expect(outcome.kind === 'unknown' && outcome.message).toContain('Do NOT repeat this call')
+    })
+  })
+
+  describe('when two identical calls overlap', () => {
+    it('runs the operation once and gives both callers the same data', async () => {
+      const dedup = createDedupFn()
+      let release: (value: { deleted: boolean }) => void = () => {}
+      const run = vi.fn(() => new Promise<{ deleted: boolean }>(resolve => (release = resolve)))
+
+      const first = dedup({ ...call(), run })
+      const second = dedup({ ...call(), run })
+      release({ deleted: true })
+
+      expect(await first).toEqual({ kind: 'executed', data: { deleted: true } })
+      expect(await second).toMatchObject({ kind: 'replayed', data: { deleted: true } })
+      expect(run).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails both callers when the shared operation fails, and stays retryable afterwards', async () => {
+      const dedup = createDedupFn()
+      const answered = new HttpError({ response: { status: 409 }, config: { method: 'post' } })
+      let reject: (reason: unknown) => void = () => {}
+      const run = vi.fn(() => new Promise<{ deleted: boolean }>((_, r) => (reject = r)))
+
+      const first = dedup({ ...call(), run })
+      const second = dedup({ ...call(), run })
+      reject(answered)
+
+      await expect(first).rejects.toBe(answered)
+      await expect(second).rejects.toBe(answered)
+
+      const outcome = await dedup({ ...call(), run: async () => ({ deleted: true }) })
+      expect(outcome.kind).toBe('executed')
+    })
+  })
+
+  describe('bypass', () => {
+    it('runs a recorded call again when a fresh confirmation says to', async () => {
+      const dedup = createDedupFn()
+      const run = vi.fn(async () => ({ deleted: true }))
+
+      await dedup({ ...call(), run })
+      const outcome = await dedup({ ...call({ bypass: true }), run })
+
+      expect(run).toHaveBeenCalledTimes(2)
+      expect(outcome.kind).toBe('executed')
+    })
+
+    it('clears an unknown outcome too', async () => {
+      const dedup = createDedupFn()
+      const failing = vi.fn(async () => {
+        throw unansweredWrite()
+      })
+
+      await expect(dedup({ ...call(), run: failing })).rejects.toThrow()
+      const outcome = await dedup({ ...call({ bypass: true }), run: async () => ({ deleted: true }) })
+
+      expect(outcome).toEqual({ kind: 'executed', data: { deleted: true } })
+    })
+  })
+})

--- a/packages/mcp/src/core/idempotency/idempotency.ts
+++ b/packages/mcp/src/core/idempotency/idempotency.ts
@@ -1,0 +1,129 @@
+import { createTtlMap } from '@/shared/ttl-map'
+
+import { callKey } from '../confirm'
+import type { DedupFn, DedupOutcome } from '../tool'
+import { classifyFailure } from './classify'
+
+/**
+ * How long a completed destructive call is remembered. Deliberately its own
+ * constant rather than a reuse of `CONFIRM_TOKEN_TTL_SECONDS`: the two windows
+ * answer different questions — a confirmation window is about how recently a
+ * human agreed, this one is about how long a client might plausibly still be
+ * retrying — and they should be free to diverge without one silently dragging
+ * the other along.
+ */
+export const IDEMPOTENCY_TTL_SECONDS = 300
+
+/**
+ * Cap on remembered calls. A recorded `marzban_config_update` carries the
+ * whole previous Xray config in `backup` — tens of kilobytes — and this
+ * process lives for days, so an unbounded store is a slow leak in the shape
+ * of a loop over ten thousand usernames.
+ */
+const MAX_ENTRIES = 256
+
+type DedupRecord =
+  | { status: 'pending'; promise: Promise<unknown>; at: number }
+  | { status: 'done'; data: unknown; at: number }
+  | { status: 'unknown'; at: number }
+
+function secondsLeft(recordedAt: number, now: number): number {
+  return Math.max(0, Math.ceil((recordedAt + IDEMPOTENCY_TTL_SECONDS * 1000 - now) / 1000))
+}
+
+function replayNotice(toolName: string, firstRunAt: number, now: number): string {
+  const ago = Math.max(0, Math.round((now - firstRunAt) / 1000))
+  return [
+    `NOTE: "${toolName}" already ran ${ago}s ago with these exact arguments.`,
+    'This is the recorded result of that call, not a new execution — nothing was sent to the panel just now.',
+    `To run it again for real, confirm it afresh, or wait ${secondsLeft(firstRunAt, now)}s for this record to expire.`,
+  ].join(' ')
+}
+
+function unknownMessage(toolName: string, recordedAt: number, now: number): string {
+  return [
+    `A previous call to "${toolName}" with these exact arguments was interrupted before its outcome could be observed —`,
+    'the panel may or may not have applied it.',
+    'Do NOT repeat this call.',
+    'Check the current state with a read-only tool first and report what you find to the user.',
+    `This call will be accepted again in ${secondsLeft(recordedAt, now)}s.`,
+  ].join(' ')
+}
+
+/**
+ * Builds the deduplication strategy for destructive tools (issue #76). One
+ * instance owns one store, scoped to the server instance's lifetime — a fresh
+ * `createMarzbanMcpServer()` starts with an empty one, the same policy the
+ * confirm signing key follows.
+ *
+ * The problem it solves sits one layer above the SDK: the SDK no longer
+ * replays an unsafe request (#75), but a client that times out waiting for
+ * `tools/call` re-issues the call, and the second one would restart the core
+ * or overwrite the config all over again. Keyed by `callKey`, so a repeat is
+ * "the same tool, the same arguments" — `confirmToken` is excluded from the
+ * hash, which is what makes a retry carrying a token match the original call.
+ *
+ * Note for future changes: the single-flight branch assumes cancellation by
+ * one caller cannot abort a shared in-flight operation. That holds because
+ * handlers receive only `ToolContext` and no `AbortSignal` is wired into SDK
+ * calls. If `serverCtx.mcpReq.signal` is ever plumbed through, cancelling the
+ * first call would abort the second caller's operation too, and the abort
+ * would have to be keyed to "every waiter has gone" instead.
+ *
+ * The store is also per-process and per-server-instance, which is sound only
+ * while the transport is stdio (one client per process). An HTTP transport
+ * would need `sessionId` folded into the key, or a per-session store.
+ */
+export function createDedupFn(): DedupFn {
+  const records = createTtlMap<DedupRecord>({ maxEntries: MAX_ENTRIES })
+
+  return async function dedup({ tool, args, bypass, run }): Promise<DedupOutcome> {
+    const key = callKey(tool.name, args)
+
+    // A freshly verified confirm token means a human just re-approved this
+    // exact operation, which is an explicit "yes, run it again" — the one
+    // thing that outranks a recorded outcome. An accidental retry can't reach
+    // here: it re-sends the already-consumed token, which fails verification.
+    if (bypass) records.delete(key)
+
+    const existing = records.get(key)
+
+    if (existing?.status === 'pending') {
+      // Single-flight: the answer is seconds away and will be exact, so wait
+      // for it rather than telling the model "unknown" about something we are
+      // about to be told. If the shared run fails, both callers see the same
+      // failure.
+      const data = await existing.promise
+      return { kind: 'replayed', data, notice: replayNotice(tool.name, existing.at, Date.now()) }
+    }
+    if (existing?.status === 'done') {
+      return { kind: 'replayed', data: existing.data, notice: replayNotice(tool.name, existing.at, Date.now()) }
+    }
+    if (existing?.status === 'unknown') {
+      return { kind: 'unknown', message: unknownMessage(tool.name, existing.at, Date.now()) }
+    }
+
+    const startedAt = Date.now()
+    const promise = run()
+    // The stored reference needs its own no-op handler: a rejected promise
+    // sitting in a map with nothing attached is an unhandled rejection, and
+    // the caller below attaches to its own reference, not to this one.
+    promise.catch(() => {})
+    records.set(key, { status: 'pending', promise, at: startedAt }, IDEMPOTENCY_TTL_SECONDS * 1000)
+
+    try {
+      const data = await promise
+      records.set(key, { status: 'done', data, at: Date.now() }, IDEMPOTENCY_TTL_SECONDS * 1000)
+      return { kind: 'executed', data }
+    } catch (err) {
+      if (classifyFailure(err) === 'unknown') {
+        records.set(key, { status: 'unknown', at: Date.now() }, IDEMPOTENCY_TTL_SECONDS * 1000)
+      } else {
+        records.delete(key)
+      }
+      // The caller that hit the failure gets the real error; only a later,
+      // identical call gets the "verify the state" steer.
+      throw err
+    }
+  }
+}

--- a/packages/mcp/src/core/idempotency/index.ts
+++ b/packages/mcp/src/core/idempotency/index.ts
@@ -1,0 +1,2 @@
+export { type Applicability, classifyFailure } from './classify'
+export { createDedupFn, IDEMPOTENCY_TTL_SECONDS } from './idempotency'

--- a/packages/mcp/src/core/tool/index.ts
+++ b/packages/mcp/src/core/tool/index.ts
@@ -2,9 +2,12 @@ export type { ToolContext } from './context'
 export { defineTool, type ToolDefinition, type ToolScope } from './define-tool'
 export { toolOutputJsonSchema } from './json-schema'
 export {
+  alwaysExecute,
   alwaysProceed,
   type ConfirmDecision,
   type ConfirmFn,
+  type DedupFn,
+  type DedupOutcome,
   registerTools,
   type RegisterToolsOptions,
   selectTools,

--- a/packages/mcp/src/core/tool/registry.test.ts
+++ b/packages/mcp/src/core/tool/registry.test.ts
@@ -9,7 +9,7 @@ import type { View } from '@/format/views/types'
 import { ToolError } from '../errors'
 import type { ToolContext } from './context'
 import { defineTool } from './define-tool'
-import { alwaysProceed, type ConfirmFn, registerTools, selectTools } from './registry'
+import { alwaysExecute, alwaysProceed, type ConfirmFn, type DedupFn, registerTools, selectTools } from './registry'
 
 type RegisteredEntry = {
   config: { title?: string; description?: string; annotations?: Record<string, unknown> }
@@ -132,6 +132,7 @@ describe('registerTools', () => {
       tools: [readTool, destructiveTool],
       ctx: makeContext({ profile: 'standard' }),
       confirm: alwaysProceed,
+      dedup: alwaysExecute,
     })
 
     expect(selected.map(t => t.name)).toEqual(['marzban_read_one'])
@@ -144,7 +145,7 @@ describe('registerTools', () => {
     const { server, registered } = createFakeServer()
     const tool = makeTool({ annotations: { idempotentHint: true, openWorldHint: false } })
 
-    registerTools({ server, tools: [tool], ctx: makeContext(), confirm: alwaysProceed })
+    registerTools({ server, tools: [tool], ctx: makeContext(), confirm: alwaysProceed, dedup: alwaysExecute })
 
     expect(registered.get('marzban_test_tool')!.config.annotations).toMatchObject({
       readOnlyHint: true,
@@ -157,7 +158,13 @@ describe('registerTools', () => {
     const { server, registered } = createFakeServer()
     const tool = makeTool()
 
-    registerTools({ server, tools: [tool], ctx: makeContext({ format: 'json' }), confirm: alwaysProceed })
+    registerTools({
+      server,
+      tools: [tool],
+      ctx: makeContext({ format: 'json' }),
+      confirm: alwaysProceed,
+      dedup: alwaysExecute,
+    })
 
     const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
     expect(result.content).toEqual([{ type: 'text', text: '{"echoed":"hi"}' }])
@@ -167,7 +174,7 @@ describe('registerTools', () => {
   it('never calls confirm for a read-scope tool', async () => {
     const { server, registered } = createFakeServer()
     const confirm = vi.fn<ConfirmFn>(() => ({ proceed: true }))
-    registerTools({ server, tools: [makeTool({ scope: 'read' })], ctx: makeContext(), confirm })
+    registerTools({ server, tools: [makeTool({ scope: 'read' })], ctx: makeContext(), confirm, dedup: alwaysExecute })
 
     await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
     expect(confirm).not.toHaveBeenCalled()
@@ -181,6 +188,7 @@ describe('registerTools', () => {
       tools: [makeTool({ scope: 'destructive' })],
       ctx: makeContext({ profile: 'full' }),
       confirm,
+      dedup: alwaysExecute,
     })
 
     const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
@@ -198,6 +206,7 @@ describe('registerTools', () => {
       tools: [makeTool({ scope: 'destructive', handler })],
       ctx: makeContext({ profile: 'full' }),
       confirm,
+      dedup: alwaysExecute,
     })
 
     const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
@@ -215,6 +224,7 @@ describe('registerTools', () => {
       tools: [makeTool({ scope: 'destructive' })],
       ctx: makeContext({ profile: 'full' }),
       confirm,
+      dedup: alwaysExecute,
     })
 
     const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
@@ -230,6 +240,7 @@ describe('registerTools', () => {
       tools: [makeTool({ scope: 'destructive', skipConfirm })],
       ctx: makeContext({ profile: 'full' }),
       confirm,
+      dedup: alwaysExecute,
     })
 
     const result = await registered.get('marzban_test_tool')!.handler({ value: 'skip' }, fakeServerCtx)
@@ -246,6 +257,7 @@ describe('registerTools', () => {
       tools: [makeTool({ scope: 'destructive', skipConfirm })],
       ctx: makeContext({ profile: 'full' }),
       confirm,
+      dedup: alwaysExecute,
     })
 
     await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
@@ -259,17 +271,142 @@ describe('registerTools', () => {
         throw new ToolError('INTERNAL_ERROR', 'handler failed')
       },
     })
-    registerTools({ server, tools: [tool], ctx: makeContext(), confirm: alwaysProceed })
+    registerTools({ server, tools: [tool], ctx: makeContext(), confirm: alwaysProceed, dedup: alwaysExecute })
 
     const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
     expect(result.isError).toBe(true)
     expect(result.content).toEqual([{ type: 'text', text: 'handler failed' }])
   })
 
+  it('never calls dedup for a non-destructive tool', async () => {
+    const { server, registered } = createFakeServer()
+    const dedup = vi.fn<DedupFn>(async ({ run }) => ({ kind: 'executed', data: await run() }))
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'write' })],
+      ctx: makeContext({ profile: 'full' }),
+      confirm: alwaysProceed,
+      dedup,
+    })
+
+    await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(dedup).not.toHaveBeenCalled()
+  })
+
+  it('never calls dedup for a call the tool itself says needs no confirmation', async () => {
+    const { server, registered } = createFakeServer()
+    const dedup = vi.fn<DedupFn>(async ({ run }) => ({ kind: 'executed', data: await run() }))
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'destructive', skipConfirm: () => true })],
+      ctx: makeContext({ profile: 'full' }),
+      confirm: alwaysProceed,
+      dedup,
+    })
+
+    const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(dedup).not.toHaveBeenCalled()
+    expect(result.structuredContent).toEqual({ echoed: 'hi' })
+  })
+
+  it('evaluates skipConfirm once per call, not once per guarded stage', async () => {
+    const { server, registered } = createFakeServer()
+    const skipConfirm = vi.fn(() => false)
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'destructive', skipConfirm })],
+      ctx: makeContext({ profile: 'full' }),
+      confirm: alwaysProceed,
+      dedup: alwaysExecute,
+    })
+
+    await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(skipConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('tells dedup to bypass its record only when a fresh token was just verified', async () => {
+    const { server, registered } = createFakeServer()
+    const dedup = vi.fn<DedupFn>(async ({ run }) => ({ kind: 'executed', data: await run() }))
+    const confirm = vi.fn<ConfirmFn>(() => ({ proceed: true, reason: 'token' }))
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'destructive' })],
+      ctx: makeContext({ profile: 'full' }),
+      confirm,
+      dedup,
+    })
+
+    await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(dedup.mock.calls[0][0].bypass).toBe(true)
+  })
+
+  it('does not bypass when the call proceeds on accumulated trust', async () => {
+    const { server, registered } = createFakeServer()
+    const dedup = vi.fn<DedupFn>(async ({ run }) => ({ kind: 'executed', data: await run() }))
+    const confirm = vi.fn<ConfirmFn>(() => ({ proceed: true, reason: 'trusted' }))
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'destructive' })],
+      ctx: makeContext({ profile: 'full' }),
+      confirm,
+      dedup,
+    })
+
+    await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(dedup.mock.calls[0][0].bypass).toBe(false)
+  })
+
+  it('flags a replayed outcome in the text while keeping the recorded structuredContent', async () => {
+    const { server, registered } = createFakeServer()
+    const handler = vi.fn(async () => ({ echoed: 'should not run' }))
+    const dedup = vi.fn<DedupFn>(async () => ({
+      kind: 'replayed',
+      data: { echoed: 'recorded' },
+      notice: 'NOTE: this already ran.',
+    }))
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'destructive', handler })],
+      ctx: makeContext({ profile: 'full', format: 'json' }),
+      confirm: alwaysProceed,
+      dedup,
+    })
+
+    const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(handler).not.toHaveBeenCalled()
+    expect(result.content).toEqual([
+      { type: 'text', text: 'NOTE: this already ran.' },
+      { type: 'text', text: '{"echoed":"recorded"}' },
+    ])
+    expect(result.structuredContent).toEqual({ echoed: 'recorded' })
+    expect(result.isError).toBeFalsy()
+  })
+
+  it('returns an unknown outcome as an error result with no structuredContent', async () => {
+    const { server, registered } = createFakeServer()
+    const dedup = vi.fn<DedupFn>(async () => ({ kind: 'unknown', message: 'Verify the state first.' }))
+    registerTools({
+      server,
+      tools: [makeTool({ scope: 'destructive' })],
+      ctx: makeContext({ profile: 'full' }),
+      confirm: alwaysProceed,
+      dedup,
+    })
+
+    const result = await registered.get('marzban_test_tool')!.handler({ value: 'hi' }, fakeServerCtx)
+    expect(result).toEqual({ content: [{ type: 'text', text: 'Verify the state first.' }], isError: true })
+  })
+
   it('returns the same tools it registered', () => {
     const { server } = createFakeServer()
     const tool = makeTool()
-    const selected = registerTools({ server, tools: [tool], ctx: makeContext(), confirm: alwaysProceed })
+    const selected = registerTools({
+      server,
+      tools: [tool],
+      ctx: makeContext(),
+      confirm: alwaysProceed,
+      dedup: alwaysExecute,
+    })
     expect(selected).toEqual([tool])
   })
 })
@@ -279,5 +416,14 @@ describe('alwaysProceed', () => {
     expect(alwaysProceed({ tool: makeTool(), args: {}, ctx: makeContext(), serverCtx: fakeServerCtx })).toEqual({
       proceed: true,
     })
+  })
+})
+
+describe('alwaysExecute', () => {
+  it('runs the operation and reports it as executed', async () => {
+    const run = vi.fn(async () => ({ echoed: 'hi' }))
+    const outcome = await alwaysExecute({ tool: makeTool(), args: {}, ctx: makeContext(), bypass: false, run })
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(outcome).toEqual({ kind: 'executed', data: { echoed: 'hi' } })
   })
 })

--- a/packages/mcp/src/core/tool/registry.ts
+++ b/packages/mcp/src/core/tool/registry.ts
@@ -18,6 +18,14 @@ export interface ConfirmDecision {
   proceed: boolean
   /** Shown to the model instead of running the tool when `proceed` is false. */
   message?: string
+  /**
+   * Why the call was allowed. `'token'` means a fresh, single-use confirm
+   * token was just verified — a human re-approved this exact operation
+   * moments ago, which is the one signal allowed to override a recorded
+   * outcome in `core/idempotency`. Optional: a `ConfirmFn` that doesn't
+   * distinguish its reasons (`alwaysProceed`) simply omits it.
+   */
+  reason?: 'off' | 'trusted' | 'token'
 }
 
 export type ConfirmFn = (input: {
@@ -33,6 +41,30 @@ export type ConfirmFn = (input: {
  * `ConfirmFn` but aren't exercising confirmation itself.
  */
 export const alwaysProceed: ConfirmFn = () => ({ proceed: true })
+
+export type DedupOutcome =
+  /** The handler ran for this call. */
+  | { kind: 'executed'; data: unknown }
+  /** An identical call already ran; `data` is what it returned, `notice` says so, and nothing was sent to the panel. */
+  | { kind: 'replayed'; data: unknown; notice: string }
+  /** An identical call was interrupted before anyone saw its outcome; `message` steers the model to verify. */
+  | { kind: 'unknown'; message: string }
+
+export type DedupFn = (input: {
+  tool: ToolDefinition<z.ZodType, z.ZodType>
+  args: unknown
+  ctx: ToolContext
+  /** Run this operation anyway, discarding any recorded outcome — set when a fresh confirm token was just verified. */
+  bypass: boolean
+  run: () => Promise<unknown>
+}) => Promise<DedupOutcome>
+
+/**
+ * A `DedupFn` that remembers nothing and always runs the handler. The
+ * counterpart to `alwaysProceed`: `createMarzbanMcpServer` uses the real store
+ * from `core/idempotency`, this is for tests that aren't exercising dedup.
+ */
+export const alwaysExecute: DedupFn = async ({ run }) => ({ kind: 'executed', data: await run() })
 
 function globToRegExp(glob: string): RegExp {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
@@ -84,6 +116,23 @@ export interface RegisterToolsOptions {
   tools: readonly ToolDefinition<z.ZodType, z.ZodType>[]
   ctx: ToolContext
   confirm: ConfirmFn
+  dedup: DedupFn
+}
+
+/**
+ * Puts the "this already ran" notice in front of the rendered result, as its
+ * own content block. `content` is free-form even for a tool that declares an
+ * `outputSchema` — only `structuredContent` is schema-bound, and it stays
+ * exactly as recorded, so the replay is honest to a program and legible to a
+ * model. Without the notice the model would report a replay as a fresh
+ * execution, which is the one failure mode a safety feature must not have.
+ *
+ * The notice sits outside the `maxChars` budget `render` already applied:
+ * going a couple of hundred characters over is better than truncating the
+ * warning itself.
+ */
+function withReplayNotice(result: CallToolResult, notice: string): CallToolResult {
+  return { ...result, content: [{ type: 'text', text: notice }, ...result.content] }
 }
 
 /**
@@ -98,12 +147,20 @@ export interface RegisterToolsOptions {
  * diagnostics.
  */
 export function registerTools(options: RegisterToolsOptions): ToolDefinition<z.ZodType, z.ZodType>[] {
-  const { server, tools, ctx, confirm } = options
+  const { server, tools, ctx, confirm, dedup } = options
   const selected = selectTools(tools, {
     profile: ctx.config.profile,
     toolsAllow: ctx.config.toolsAllow,
     toolsDeny: ctx.config.toolsDeny,
   })
+  // Config is read once at startup and fixed for the process, so these are
+  // the same for every call and every tool.
+  const renderOptions = {
+    format: ctx.config.format,
+    verbosity: ctx.config.verbosity,
+    maxChars: ctx.config.maxChars,
+    showLinks: ctx.config.showLinks,
+  }
 
   for (const tool of selected) {
     server.registerTool(
@@ -117,28 +174,46 @@ export function registerTools(options: RegisterToolsOptions): ToolDefinition<z.Z
       },
       async (args: unknown, serverCtx: ServerContext): Promise<CallToolResult> => {
         try {
-          if (tool.scope === 'destructive' && !(tool.skipConfirm?.(args, ctx) ?? false)) {
-            const decision = await confirm({ tool, args, ctx, serverCtx })
-            if (!decision.proceed) {
-              // isError: true, not false — every destructive tool declares
-              // an outputSchema, and the SDK requires structuredContent on
-              // every non-error result that has one (it has no bearing on
-              // this tool's actual output shape, so there's nothing honest
-              // to put there). The model still reads `content` either way.
-              return {
-                content: [{ type: 'text', text: decision.message ?? 'Confirmation required.' }],
-                isError: true,
-              }
+          // One evaluation of `skipConfirm` for both guarded stages: it is
+          // author-supplied and need not be pure, and a dry run must reach
+          // neither of them.
+          const guarded = tool.scope === 'destructive' && !(tool.skipConfirm?.(args, ctx) ?? false)
+          if (!guarded) return render(await tool.handler(args, ctx), tool.view, renderOptions)
+
+          const decision = await confirm({ tool, args, ctx, serverCtx })
+          if (!decision.proceed) {
+            // isError: true, not false — every destructive tool declares
+            // an outputSchema, and the SDK requires structuredContent on
+            // every non-error result that has one (it has no bearing on
+            // this tool's actual output shape, so there's nothing honest
+            // to put there). The model still reads `content` either way.
+            return {
+              content: [{ type: 'text', text: decision.message ?? 'Confirmation required.' }],
+              isError: true,
             }
           }
 
-          const data = await tool.handler(args, ctx)
-          return render(data, tool.view, {
-            format: ctx.config.format,
-            verbosity: ctx.config.verbosity,
-            maxChars: ctx.config.maxChars,
-            showLinks: ctx.config.showLinks,
+          // Confirmation first, dedup second: the key deliberately ignores
+          // `confirmToken`, so a caller presenting no token hashes to the
+          // same key as the confirmed original. Deduping first would hand
+          // that caller the recorded result — for `marzban_config_update`,
+          // the entire previous core config — past the gate.
+          const outcome = await dedup({
+            tool,
+            args,
+            ctx,
+            bypass: decision.reason === 'token',
+            run: () => tool.handler(args, ctx),
           })
+
+          // isError for the same reason the decline branch above is: there
+          // is no honest structuredContent for an outcome nobody observed.
+          if (outcome.kind === 'unknown') {
+            return { content: [{ type: 'text', text: outcome.message }], isError: true }
+          }
+
+          const result = render(outcome.data, tool.view, renderOptions)
+          return outcome.kind === 'replayed' ? withReplayNotice(result, outcome.notice) : result
         } catch (err) {
           return toToolError(err)
         }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/server'
 
 import { createConfirmFn } from './core/confirm'
+import { createDedupFn } from './core/idempotency'
 import { registerPrompts } from './core/prompts'
 import type { ToolContext } from './core/tool'
 import { registerTools } from './core/tool'
@@ -21,6 +22,7 @@ const SERVER_INSTRUCTIONS = `This server manages a Marzban VPN panel. A few rule
 - Before a real marzban_config_update, call it once with \`dryRun: true\` and show the user the diff. Only send the real write after they've seen it and agreed — it restarts the core and drops every connection.
 - A destructive tool's first response describes what it would do and includes a confirmToken. Only repeat the call with that token after the user has given their own, unprompted "yes" — the token being available is not itself permission.
 - Confirming a destructive call only covers that exact tool and those exact arguments. A different target, or a wider version of the same call (e.g. adding \`all: true\`), needs its own confirmation.
+- If a destructive tool reports that its outcome is unknown, do not call it again. Check the current state with a read-only tool and tell the user what you find.
 - For multi-step investigations (expiring subscriptions, node health, bandwidth), check whether a prompt already covers it (expiring_users_audit, node_diagnostics, traffic_report) before improvising a tool sequence by hand.`
 
 // tools/list is fully determined by MARZBAN_MCP_PROFILE/_TOOLS_ALLOW/_TOOLS_DENY,
@@ -39,7 +41,9 @@ export function createMarzbanMcpServer(info: McpServerInfo, ctx: ToolContext): M
   })
   // A fresh confirm strategy per server instance — its signing key and
   // trustedTools set are meant to live and die with the server (plan §6.1).
-  registerTools({ server, tools: allTools, ctx, confirm: createConfirmFn() })
+  // The dedup store follows the same policy: a restarted server has no memory
+  // of what a previous run executed, and must not pretend otherwise.
+  registerTools({ server, tools: allTools, ctx, confirm: createConfirmFn(), dedup: createDedupFn() })
   registerPrompts(server, allPrompts)
   return server
 }

--- a/packages/mcp/src/shared/ttl-map.test.ts
+++ b/packages/mcp/src/shared/ttl-map.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTtlMap } from './ttl-map'
+
+describe('createTtlMap', () => {
+  it('returns a stored value before its TTL elapses', () => {
+    const map = createTtlMap<string>()
+    map.set('a', 'value', 1000)
+    expect(map.get('a')).toBe('value')
+  })
+
+  it('returns undefined for a key that was never set', () => {
+    expect(createTtlMap<string>().get('missing')).toBeUndefined()
+  })
+
+  it('overwrites an existing key and refreshes its TTL', () => {
+    const map = createTtlMap<string>()
+    map.set('a', 'first', 1000)
+    map.set('a', 'second', 1000)
+    expect(map.get('a')).toBe('second')
+    expect(map.size).toBe(1)
+  })
+
+  it('forgets a deleted key', () => {
+    const map = createTtlMap<string>()
+    map.set('a', 'value', 1000)
+    map.delete('a')
+    expect(map.get('a')).toBeUndefined()
+  })
+
+  describe('expiry', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('returns undefined once the TTL has elapsed', () => {
+      const map = createTtlMap<string>()
+      map.set('a', 'value', 1000)
+      vi.advanceTimersByTime(1001)
+      expect(map.get('a')).toBeUndefined()
+    })
+
+    it('sweeps expired entries out instead of merely hiding them', () => {
+      const map = createTtlMap<string>()
+      map.set('a', 'value', 1000)
+      expect(map.size).toBe(1)
+      vi.advanceTimersByTime(1001)
+      expect(map.size).toBe(0)
+    })
+
+    it('sweeps a stale entry when an unrelated key is written', () => {
+      const map = createTtlMap<string>()
+      map.set('a', 'value', 1000)
+      vi.advanceTimersByTime(1001)
+      map.set('b', 'other', 1000)
+      expect(map.get('a')).toBeUndefined()
+      expect(map.get('b')).toBe('other')
+    })
+  })
+
+  describe('maxEntries', () => {
+    it('evicts the oldest entry when the cap would be exceeded', () => {
+      const map = createTtlMap<string>({ maxEntries: 2 })
+      map.set('a', 'first', 1000)
+      map.set('b', 'second', 1000)
+      map.set('c', 'third', 1000)
+      expect(map.get('a')).toBeUndefined()
+      expect(map.get('b')).toBe('second')
+      expect(map.get('c')).toBe('third')
+      expect(map.size).toBe(2)
+    })
+
+    it('does not evict while below the cap', () => {
+      const map = createTtlMap<string>({ maxEntries: 2 })
+      map.set('a', 'first', 1000)
+      expect(map.get('a')).toBe('first')
+      expect(map.size).toBe(1)
+    })
+
+    it('treats a re-set key as the newest, not the oldest', () => {
+      const map = createTtlMap<string>({ maxEntries: 2 })
+      map.set('a', 'first', 1000)
+      map.set('b', 'second', 1000)
+      map.set('a', 'refreshed', 1000)
+      map.set('c', 'third', 1000)
+      expect(map.get('a')).toBe('refreshed')
+      expect(map.get('b')).toBeUndefined()
+    })
+
+    it('keeps every entry when no cap is configured', () => {
+      const map = createTtlMap<string>()
+      map.set('a', 'first', 1000)
+      map.set('b', 'second', 1000)
+      map.set('c', 'third', 1000)
+      expect(map.size).toBe(3)
+    })
+  })
+})

--- a/packages/mcp/src/shared/ttl-map.ts
+++ b/packages/mcp/src/shared/ttl-map.ts
@@ -1,0 +1,69 @@
+export interface TtlMap<V> {
+  /** The stored value, or `undefined` when the key was never set or its entry has expired. */
+  get(key: string): V | undefined
+  set(key: string, value: V, ttlMs: number): void
+  delete(key: string): void
+  /** Live entries only — expired ones are swept before counting. */
+  readonly size: number
+}
+
+export interface TtlMapOptions {
+  /** Hard cap on live entries; the oldest insertion is evicted when a new key would exceed it. Omit for no cap. */
+  maxEntries?: number
+}
+
+/**
+ * A `Map` whose entries expire, sweeping on access rather than on a timer.
+ *
+ * The no-timer part is deliberate, not an optimization: a `setInterval` keeps
+ * the Node event loop alive, and this server talks stdio — a lingering timer
+ * turns a clean exit into a hang. Every read and write pays for one sweep of
+ * the (small, TTL-bounded) map instead.
+ *
+ * `maxEntries` bounds memory for a long-lived process: without it, a loop over
+ * ten thousand usernames retains ten thousand entries until their TTLs pass.
+ * Eviction is oldest-insertion-first, which `Map`'s iteration order gives for
+ * free.
+ */
+export function createTtlMap<V>(options: TtlMapOptions = {}): TtlMap<V> {
+  const entries = new Map<string, { value: V; expiresAt: number }>()
+  const { maxEntries } = options
+
+  function sweep(now: number): void {
+    for (const [key, entry] of entries) {
+      if (entry.expiresAt <= now) entries.delete(key)
+    }
+  }
+
+  return {
+    get(key) {
+      sweep(Date.now())
+      return entries.get(key)?.value
+    },
+
+    set(key, value, ttlMs) {
+      const now = Date.now()
+      sweep(now)
+      // Delete first so a re-set moves the key to the end of the insertion
+      // order — otherwise a refreshed entry would still be evicted as if it
+      // were the oldest one.
+      entries.delete(key)
+      if (maxEntries !== undefined) {
+        for (const oldest of entries.keys()) {
+          if (entries.size < maxEntries) break
+          entries.delete(oldest)
+        }
+      }
+      entries.set(key, { value, expiresAt: now + ttlMs })
+    },
+
+    delete(key) {
+      entries.delete(key)
+    },
+
+    get size() {
+      sweep(Date.now())
+      return entries.size
+    },
+  }
+}

--- a/packages/mcp/test/integration/helpers/pipeline.ts
+++ b/packages/mcp/test/integration/helpers/pipeline.ts
@@ -1,0 +1,40 @@
+import type { CallToolResult, McpServer, ServerContext } from '@modelcontextprotocol/server'
+
+import { createConfirmFn } from '../../../src/core/confirm'
+import { createDedupFn } from '../../../src/core/idempotency'
+import { registerTools, type ToolContext } from '../../../src/core/tool'
+
+type RegisteredHandler = (args: unknown, serverCtx: ServerContext) => Promise<CallToolResult>
+
+const fakeServerCtx = {} as ServerContext
+
+/**
+ * Drives a tool the way a real client does — through the registry pipeline,
+ * with the real confirm and dedup strategies wired in. Confirmation and
+ * deduplication are registry stages, so a test that calls `tool.handler`
+ * directly proves nothing about either.
+ *
+ * Returns a `call(args)` function over a single freshly registered tool; each
+ * call to this helper builds its own strategies, so one test's confirmation
+ * trust and recorded outcomes never leak into another's.
+ */
+export function registerForCall(
+  tool: Parameters<typeof registerTools>[0]['tools'][number],
+  ctx: ToolContext
+): (args: unknown) => Promise<CallToolResult> {
+  const registered = new Map<string, RegisteredHandler>()
+  const server = {
+    registerTool: (name: string, _config: unknown, handler: RegisteredHandler) => {
+      registered.set(name, handler)
+    },
+  } as unknown as McpServer
+
+  registerTools({ server, tools: [tool], ctx, confirm: createConfirmFn(), dedup: createDedupFn() })
+  const handler = registered.get(tool.name)!
+  return (args: unknown) => handler(args, fakeServerCtx)
+}
+
+/** The text channel of a tool result, joined — what the model actually reads. */
+export function resultText(result: CallToolResult): string {
+  return (result.content as { type: string; text: string }[]).map(part => part.text).join('\n')
+}

--- a/packages/mcp/test/integration/smoke.integration.test.ts
+++ b/packages/mcp/test/integration/smoke.integration.test.ts
@@ -11,6 +11,7 @@ import { type ToolContext, toolOutputJsonSchema } from '../../src/core/tool'
 import { nodesListTool } from '../../src/modules/nodes/nodes.tools'
 import { usersCreateTool, usersDeleteTool, usersExtendTool } from '../../src/modules/users/users.tools'
 import { createTestToolContext } from './helpers/client'
+import { registerForCall, resultText } from './helpers/pipeline'
 import { freshConnectionConfig, removeUserTolerantly } from './helpers/quirks'
 
 // Same validator shape a strict MCP client applies to structuredContent: a
@@ -90,7 +91,9 @@ describe('MCP tool smoke tests (real SDK, real panel)', () => {
       ctx,
       serverCtx: fakeServerCtx,
     })
-    expect(second).toEqual({ proceed: true })
+    // `reason: 'token'` is what tells the dedup store this is a human's fresh
+    // re-approval rather than a retry, so it must survive the round trip.
+    expect(second).toEqual({ proceed: true, reason: 'token' })
 
     try {
       const result = await usersDeleteTool.handler(args, ctx)
@@ -100,6 +103,39 @@ describe('MCP tool smoke tests (real SDK, real panel)', () => {
       expect(isHttpError(err)).toBe(true)
       expect(isHttpError(err) && err.status).toBe(500)
     }
+
+    await expect(ctx.sdk.user.getUser(username, freshConnectionConfig())).rejects.toMatchObject({ status: 404 })
+  })
+
+  it('marzban_users_delete: a repeated call replays the recorded result instead of deleting twice (#76)', async () => {
+    const base = await createTestToolContext()
+    // 'auto', not the helper's 'always': in 'always' a bare repeat is turned
+    // away by confirmation and never reaches dedup, so the replay this test
+    // exists to prove would be unobservable.
+    ctx = { ...base, config: { ...base.config, confirm: 'auto' } }
+    const username = uniqueUsername('dedup')
+    await ctx.sdk.user.addUser({ username, status: 'active', proxies: SHADOWSOCKS_PROXY })
+
+    const call = registerForCall(usersDeleteTool, ctx)
+
+    const declined = await call({ username })
+    expect(declined.isError).toBe(true)
+    const token = resultText(declined).match(/confirmToken: "([^"]+)"/)![1]
+
+    const executed = await call({ username, confirmToken: token })
+    expect(executed.isError).toBeUndefined()
+    expect(executed.structuredContent).toEqual({ username, deleted: true })
+
+    // The retry a timing-out client sends: same arguments, no token. Before
+    // #76 this reached the panel a second time and came back 404 — the user
+    // is already gone, and removeUser only tolerates the 500 quirk, not a
+    // 404. Getting the first call's result back is therefore proof the panel
+    // was never asked again, not just that the shapes happen to match.
+    const replayed = await call({ username })
+    expect(replayed.isError).toBeUndefined()
+    expect(replayed.structuredContent).toEqual({ username, deleted: true })
+    expect(resultText(replayed)).toContain('already ran')
+    expect(resultText(replayed)).toContain('nothing was sent to the panel just now')
 
     await expect(ctx.sdk.user.getUser(username, freshConnectionConfig())).rejects.toMatchObject({ status: 404 })
   })

--- a/packages/mcp/test/integration/users-lifecycle.integration.test.ts
+++ b/packages/mcp/test/integration/users-lifecycle.integration.test.ts
@@ -72,7 +72,7 @@ describe('MCP full user lifecycle + config read/dry-run (real SDK, real panel)',
         ctx,
         serverCtx: fakeServerCtx,
       })
-      expect(second).toEqual({ proceed: true })
+      expect(second).toEqual({ proceed: true, reason: 'token' })
 
       try {
         const deleted = await usersDeleteTool.handler(args, ctx)


### PR DESCRIPTION
Closes #76.

## What this fixes

#75 stopped the SDK from replaying an unsafe request. This is the same problem one layer up: an MCP client that times out waiting for `tools/call` re-issues the call, and `registry.ts` ran `tool.handler` for whatever it was handed. For `marzban_core_restart` that was a second restart; for `marzban_config_update` a second overwrite.

`confirm: 'auto'` made it worse rather than better — after #74 a repeat with identical arguments proceeds without re-asking (correct for a prompt), which is exactly what let the retry reach the panel again. The confirmation gate answers "may this run?"; nothing answered "has this already run?".

## How

A dedup stage in the tool pipeline, after confirmation, for `destructive` tools in every confirm mode (in `off` it is the only protection left):

- **Key** — `callKey(tool.name, args)`, moved out of `confirm.ts` into `canonical.ts` so the trust cache and the dedup store share one definition of "the same call". `confirmToken` is excluded from the hash, so a retry carrying one still matches the original call.
- **Fresh** → runs, records the handler's plain data for 5 minutes.
- **Repeat** → returns the recorded data with a leading notice saying it is a recording. `structuredContent` is byte-identical to what was recorded; only `content` gains the notice. Without it, a model would report a replay as a fresh execution — the one failure mode a safety feature must not have.
- **Unknown** → only when an unsafe request was dispatched and got no answer at all. `classify.ts` treats everything else as provably not applied (the panel answering 4xx/5xx, a failure before dispatch, a failure on the read that destructive handlers do before they write), so those stay retryable. A later identical call is told to verify state with a read tool instead of guessing.
- **Concurrent duplicates** share one execution rather than being answered `unknown` — the exact answer is seconds away.
- **A freshly verified token bypasses the record.** `ConfirmDecision` now reports why a call was allowed; `reason: 'token'` means a human re-approved this exact operation moments ago. Without this, `confirm: 'always'` would answer a deliberate second restart with a four-minute-old result. An accidental retry can't reach this path — it re-sends the consumed token, which fails verification as `reused`.
- **TTL 300s**, its own constant rather than an import of `CONFIRM_TOKEN_TTL_SECONDS` (the two windows are equal by coincidence of judgment, not by dependency), store capped at 256 entries, process memory only — a restart clears it.

`shared/ttl-map.ts` is a new helper for the store; `usedJti` and `trustedCalls` still have their own copies, migrating them is a follow-up so this PR's review stays about the safety change.

## Verification

- `pnpm --filter marzban-mcp test:coverage` — 459 tests, 100% statements/branches/functions/lines.
- `pnpm lint`, `tsc --noEmit`, `pnpm --filter marzban-mcp build`, and a full docs-site build all pass.
- **Not yet run against a live panel.** The Inspector walkthrough in the plan (confirm → execute → repeat replays → wait out the window → panel down gives `unknown`) still needs doing on a real checkout.

## Docs

ADR-0019 records the decisions and their costs — including two that are worth knowing before merging: in `auto`, a deliberate immediate re-run of an argument-less tool isn't expressible (the trust cache is consulted before the token), and an unreachable panel poisons a key with `unknown` for the window because `ECONNREFUSED` is indistinguishable from a timeout without a `transportCode` getter on `HttpError`. Both have follow-up issues.

Also corrects two stale notes claiming this package reads `HttpError.details` by duck-typing — it uses the public `status`/`method` getters.