### PR TITLE
test(mcp): budget the size of tools/list

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,6 +1,6 @@
 # Conventions
 
-**Covers:** code style enforcement, commit format, branching model.
+**Covers:** code style enforcement, commit format, the context budget, branching model.
 **Excludes:** how to run lint/test locally (see [workspace.md](./workspace.md)),
 what CI enforces (see [ci.md](./ci.md)).
 **Next:** [testing.md](./testing.md).
@@ -55,6 +55,28 @@ type) for an sdk commit that also changes marzban-mcp's observable behavior
 commits scoped this way and surfaces them in mcp's changelog too, since
 mcp's changelog is otherwise generated only from `packages/mcp/**` commits.
 See [release.md](./release.md) for the full mechanism.
+
+## Context budget
+
+`marzban-mcp` sends its whole `tools/list` at the start of every
+conversation, so the size of that payload is a cost every user pays in every
+session. `packages/mcp/src/tools-list-budget.test.ts` pins it: per profile
+(`readonly`, `standard`, `full`), the tool count exactly and the serialised
+byte size against a ceiling in `TOOLS_LIST_BUDGET`. It fails in CI like any
+other broken assertion — see [ci.md](./ci.md).
+
+The budgets carry ~5% headroom, which is more than every tool description in
+the server put together, so ordinary rewording never trips them. Going over
+therefore means something structural changed — a new tool, or a schema that
+grew.
+
+**Raising a number in `TOOLS_LIST_BUDGET` is its own commit, and the commit
+message says why the extra context is worth paying for.** Never fold a
+budget bump into the change that caused it: the whole point of the test is
+that growth gets noticed and argued for once, rather than accumulating a
+sentence at a time inside unrelated diffs. The same rule applies to the tool
+count — adding a tool is a deliberate decision about what every conversation
+pays for, not a detail of the commit that implements it.
 
 ## Pre-commit
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,15 @@ pnpm --filter marzban-sdk test:coverage
   (open-ended OpenAPI objects silently losing keys on parse) so a future
   `codegen` run against an imprecise spec fails the suite instead of shipping
   a bug. See [`packages/sdk/ARCHITECTURE.md`](../packages/sdk/ARCHITECTURE.md).
+- **Budget** — `packages/mcp/src/tools-list-budget.test.ts` drives a real
+  server over an in-memory transport, asks it the actual `tools/list`
+  question, and asserts the serialised answer stays under a per-profile
+  ceiling. Coverage says nothing about payload size — a description can
+  triple in length with every line still covered — and this payload is sent
+  in full at the start of every conversation. On failure it prints a
+  per-tool breakdown (description / input schema / output schema), so the
+  message says what grew. The budgets themselves and the rule for raising
+  one live in [conventions.md](./conventions.md#context-budget).
 - **Integration** — `packages/sdk/test/integration/**/*.integration.test.ts`
   and `packages/mcp/test/integration/**/*.integration.test.ts` run against a
   real Marzban panel (no mocked transport). Separate configs

--- a/packages/mcp/src/tools-list-budget.test.ts
+++ b/packages/mcp/src/tools-list-budget.test.ts
@@ -1,0 +1,156 @@
+import type { JSONRPCMessage, ListToolsResult, Tool } from '@modelcontextprotocol/server'
+import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server'
+import type { MarzbanSDK } from 'marzban-sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { McpConfig } from '@/config'
+import type { ToolContext } from '@/core/tool'
+
+import { createMarzbanMcpServer } from './server'
+
+/**
+ * `tools/list` is sent in full at the start of every conversation, so its
+ * serialised size is a cost every user of this server pays on every session —
+ * unlike a handler, which only costs anything when it's actually called. The
+ * 100% coverage thresholds in `vitest.shared.ts` say nothing about it: a
+ * description can triple in length with coverage untouched (#77).
+ *
+ * Measured on the real payload — the server is driven over an in-memory
+ * transport and asked the actual `tools/list` question — rather than
+ * reconstructed from `selectTools()` + the zod→JSON Schema helpers. A
+ * reconstruction would silently stop covering whatever `registerTools` adds
+ * on top (annotations, titles, the schema conversion the MCP SDK does
+ * itself), which is exactly the part most likely to grow without anyone
+ * noticing.
+ *
+ * Bytes, not tokens: deterministic, needs no tokeniser dependency, and moves
+ * proportionally with what actually matters. For a rough conversion, this
+ * payload runs at roughly 4 characters per token — so the `full` budget below
+ * is on the order of 16k tokens.
+ */
+
+/** Each profile's tool count, and the ceiling on its serialised `tools/list`.
+ *
+ * Measured 2026-09-06 at marzban-mcp 0.2.2 by this test (add a `console.log`
+ * of `measure().bytes`, or read the number off a failure message — it prints
+ * both the actual and the budget):
+ *
+ *   readonly  9 tools  22 636 B
+ *   standard 15 tools  48 223 B
+ *   full     21 tools  62 816 B
+ *
+ * Budgets are those numbers plus ~5%, rounded to something legible. That
+ * headroom is deliberate: 5% of `full` is ~3 KB, which is more than every
+ * tool description in the server put together (4.9 KB at the time of
+ * measurement), so ordinary rewording never fails CI — but it is also less
+ * than one average tool (~3 KB), so a new tool has to come with a deliberate
+ * budget change. `tools` is pinned exactly for the same reason: a budget
+ * alone would let a tool be added under cover of a few shortened
+ * descriptions.
+ *
+ * Raising a number here is its own commit, with the justification in the
+ * message — see docs/conventions.md, "Context budget".
+ */
+const TOOLS_LIST_BUDGET: Record<McpConfig['profile'], { tools: number; bytes: number }> = {
+  readonly: { tools: 9, bytes: 24_000 },
+  standard: { tools: 15, bytes: 51_000 },
+  full: { tools: 21, bytes: 66_000 },
+}
+
+function makeContext(profile: McpConfig['profile']): ToolContext {
+  return {
+    sdk: {} as MarzbanSDK,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    config: {
+      baseUrl: 'https://panel.example.com',
+      username: 'admin',
+      password: 'secret',
+      profile,
+      format: 'text',
+      verbosity: 'compact',
+      confirm: 'auto',
+      maxChars: 8000,
+      logLevel: 'warn',
+      showLinks: false,
+    },
+  }
+}
+
+/**
+ * Asks a real, fully registered server for `tools/list` over a linked
+ * in-memory transport pair, driving the handshake by hand (`initialize` →
+ * `notifications/initialized` → `tools/list`) since this package depends on
+ * the server SDK only — there's no client to borrow.
+ */
+async function fetchToolsList(profile: McpConfig['profile']): Promise<ListToolsResult> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const server = createMarzbanMcpServer({ name: 'marzban-mcp', version: '0.0.0' }, makeContext(profile))
+
+  const pending = new Map<number, (result: unknown) => void>()
+  clientTransport.onmessage = message => {
+    if ('id' in message && 'result' in message) pending.get(Number(message.id))?.(message.result)
+  }
+
+  await clientTransport.start()
+  await server.connect(serverTransport)
+
+  async function request(id: number, method: string, params: Record<string, unknown>): Promise<unknown> {
+    const answered = new Promise<unknown>(resolve => pending.set(id, resolve))
+    await clientTransport.send({ jsonrpc: '2.0', id, method, params } as JSONRPCMessage)
+    return answered
+  }
+
+  try {
+    await request(1, 'initialize', {
+      protocolVersion: LATEST_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'tools-list-budget', version: '0.0.0' },
+    })
+    await clientTransport.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage)
+    return (await request(2, 'tools/list', {})) as ListToolsResult
+  } finally {
+    await clientTransport.close()
+  }
+}
+
+/**
+ * Printed only when a budget fails, so the failure says *which* tool grew
+ * instead of only that the total did. Descriptions and the two schemas are
+ * split out because they're the three things that move independently — and
+ * in this server the schemas are by far the larger share.
+ */
+function breakdown(tools: Tool[]): string {
+  const rows = tools
+    .map(tool => ({
+      name: tool.name,
+      total: JSON.stringify(tool).length,
+      description: JSON.stringify(tool.description ?? '').length,
+      input: JSON.stringify(tool.inputSchema ?? {}).length,
+      output: JSON.stringify(tool.outputSchema ?? {}).length,
+    }))
+    .sort((a, b) => b.total - a.total)
+
+  return rows
+    .map(r => `  ${r.name.padEnd(34)} total ${r.total}  (description ${r.description}, in ${r.input}, out ${r.output})`)
+    .join('\n')
+}
+
+describe('tools/list context budget', () => {
+  it.each(Object.keys(TOOLS_LIST_BUDGET) as McpConfig['profile'][])('%s profile stays within budget', async profile => {
+    const budget = TOOLS_LIST_BUDGET[profile]
+    const result = await fetchToolsList(profile)
+    const bytes = JSON.stringify(result).length
+
+    expect(
+      result.tools.map(tool => tool.name),
+      `The ${profile} profile no longer exposes ${budget.tools} tools. Adding or removing one changes what every ` +
+        `conversation pays for — update TOOLS_LIST_BUDGET in its own commit, with the reason in the message.`
+    ).toHaveLength(budget.tools)
+
+    expect(
+      bytes,
+      `tools/list for the ${profile} profile is ${bytes} bytes, over its ${budget.bytes}-byte budget ` +
+        `(see docs/conventions.md, "Context budget"). Per tool:\n${breakdown(result.tools)}`
+    ).toBeLessThanOrEqual(budget.bytes)
+  })
+})


### PR DESCRIPTION
Closes #77.

`tools/list` is sent in full at the start of every conversation, so its size is a cost every user pays in every session. Nothing measured it, and the 100% coverage thresholds say nothing about it — a description can triple in length with every line still covered.

## What the test does

`packages/mcp/src/tools-list-budget.test.ts` drives a real, fully registered server over a linked in-memory transport pair, runs the handshake by hand (`initialize` → `notifications/initialized` → `tools/list`), and measures the serialised answer.

Measuring the real payload rather than rebuilding it from `selectTools()` + the zod→JSON Schema helpers is deliberate: a reconstruction would silently stop covering whatever `registerTools` adds on top (annotations, titles, the conversion the MCP SDK does itself), which is the part most likely to grow unnoticed.

Bytes, not tokens: deterministic, no tokeniser dependency, moves proportionally with what matters. This payload runs at roughly 4 chars/token, so `full` is on the order of 16k tokens.

## Budgets

Measured 2026-09-06 at marzban-mcp 0.2.2:

| profile | tools | measured | budget | headroom |
| --- | --- | --- | --- | --- |
| `readonly` | 9 | 22,636 B | 24,000 | +6.0% |
| `standard` | 15 | 48,223 B | 51,000 | +5.8% |
| `full` | 21 | 62,816 B | 66,000 | +5.1% |

~5% is chosen, not rounded to: 5% of `full` is ~3.1 KB, which is more than every tool description in the server put together (4.9 KB), so ordinary rewording never fails CI — and it is less than one average tool (~3.0 KB), so a new tool has to come with a deliberate budget change.

`standard` is measured too, though #77 only asked for `readonly` and `full` — it is the default profile, so it is the number most users actually pay.

The tool count is pinned exactly alongside the byte budget. A byte budget alone would let a tool be added under cover of a few shortened descriptions.

## Failure output

The assertion message prints a per-tool breakdown, sorted by size, so a failure says *what* grew:

```
tools/list for the full profile is 62816 bytes, over its 60000-byte budget
(see docs/conventions.md, "Context budget"). Per tool:
  marzban_hosts_update      total 5461  (description 247, in 1902, out 3115)
  marzban_users_create      total 5437  (description 293, in 1905, out 3057)
  ...
```

## CI

No workflow change needed — `ci.yml` already runs `turbo run test`, so this gates the merge like any other assertion.

## Docs

- `docs/conventions.md` gains a "Context budget" section with the rule: raising a number in `TOOLS_LIST_BUDGET` is its own commit, with the justification in the message, never folded into the change that caused it.
- `docs/testing.md` gains a "Budget" level next to the existing generator and output-schema regressions.

## Follow-up

Measuring the payload also showed where the weight actually is: descriptions are 8% of `full`, `outputSchema` is 68%. Filed separately as #130 — this PR only pins the current size.
