### PR TITLE
feat(sdk): expose transport-level error code on HttpError

### DIFF
--- a/apps/docs/content/docs/advanced/error-handling.mdx
+++ b/apps/docs/content/docs/advanced/error-handling.mdx
@@ -131,15 +131,18 @@ try {
   const user = await sdk.user.getUser('non-existent')
 } catch (err) {
   if (isHttpError(err)) {
-    console.error('HTTP status:', err.status)       // 404, or undefined if the request never got a response
-    console.error('Status text:', err.statusText)    // "Not Found"
-    console.error('Response body:', err.data)        // whatever the server returned
-    console.error('Request:', err.method, err.url)    // "GET", "/api/user/non-existent"
+    console.error('HTTP status:', err.status)             // 404, or undefined if the request never got a response
+    console.error('Status text:', err.statusText)          // "Not Found"
+    console.error('Response body:', err.data)              // whatever the server returned
+    console.error('Request:', err.method, err.url)          // "GET", "/api/user/non-existent"
+    console.error('Transport code:', err.transportCode)    // "ECONNREFUSED", "ETIMEDOUT", … — set only when there was no response
   }
 }
 ```
 
 `status`/`statusText`/`data`/`method`/`url` are all `undefined` when there was no response to read them from — a network failure, a timeout, or a DNS error never reaches the server, so there's no status code to report. Check for `undefined` rather than assuming a response always exists.
+
+When there's no response, `transportCode` fills in the reason: it carries the underlying transport-level error code (`ECONNREFUSED`, `ETIMEDOUT`, `ENOTFOUND`, `ERR_CANCELED`, …), letting you distinguish "the connection was refused" from "the request timed out mid-flight" — a distinction that matters when deciding whether a failed write is safe to retry.
 
 ### Handling config errors
 

--- a/packages/mcp/ARCHITECTURE.md
+++ b/packages/mcp/ARCHITECTURE.md
@@ -255,8 +255,10 @@ automatically.
 - The tool list is documented by hand in three places (code, `README.md`,
   the docs site) with nothing checking they agree — see
   [`docs/architecture.md`](../../docs/architecture.md).
-- `core/idempotency/classify.ts` can't tell "the connection was refused, so
-  nothing was applied" from "an in-flight write timed out", because the
-  transport-level error code has no public accessor on `HttpError`. It
-  errs toward `unknown`, so an unreachable panel produces a needless "verify
-  the state" answer for the length of the dedup window — see ADR-0019.
+- ~~`core/idempotency/classify.ts` can't tell "the connection was refused, so
+  nothing was applied" from "an in-flight write timed out"~~ — closed.
+  `HttpError.transportCode` (marzban-sdk) exposes the transport-level code,
+  and `classify.ts` now treats `ECONNREFUSED`/`ENOTFOUND`/`EAI_AGAIN` as
+  `not-applied` since the request never left the client. `ETIMEDOUT` and
+  similar codes still resolve to `unknown` — a timeout can happen after an
+  in-flight write was already sent. See ADR-0019.

--- a/packages/mcp/src/core/idempotency/classify.test.ts
+++ b/packages/mcp/src/core/idempotency/classify.test.ts
@@ -54,4 +54,20 @@ describe('classifyFailure', () => {
   it('treats an unanswered DELETE as unknown', () => {
     expect(classifyFailure(new HttpError({ config: { method: 'delete' } }))).toBe('unknown')
   })
+
+  it('treats a refused connection as not applied, regardless of method', () => {
+    expect(classifyFailure(new HttpError({ code: 'ECONNREFUSED', config: { method: 'delete' } }))).toBe('not-applied')
+  })
+
+  it('treats an unresolved host as not applied', () => {
+    expect(classifyFailure(new HttpError({ code: 'ENOTFOUND', config: { method: 'post' } }))).toBe('not-applied')
+  })
+
+  it('treats a DNS lookup timeout as not applied', () => {
+    expect(classifyFailure(new HttpError({ code: 'EAI_AGAIN', config: { method: 'post' } }))).toBe('not-applied')
+  })
+
+  it('treats an in-flight write timeout as unknown — the transport code does not rule out delivery', () => {
+    expect(classifyFailure(new HttpError({ code: 'ETIMEDOUT', config: { method: 'delete' } }))).toBe('unknown')
+  })
 })

--- a/packages/mcp/src/core/idempotency/classify.ts
+++ b/packages/mcp/src/core/idempotency/classify.ts
@@ -7,6 +7,14 @@ import { isHttpError } from 'marzban-sdk'
  */
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 
+/**
+ * Transport-level codes that prove the request never left the client — the
+ * connection was refused, or the host couldn't be resolved at all. Excludes
+ * `ETIMEDOUT`/`ECONNABORTED`: a timeout can happen after an in-flight write
+ * was already sent, so those stay `unknown`.
+ */
+const NEVER_DISPATCHED_CODES = new Set(['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN'])
+
 /** Whether a failed call could have changed anything on the panel. */
 export type Applicability = 'not-applied' | 'unknown'
 
@@ -17,15 +25,8 @@ export type Applicability = 'not-applied' | 'unknown'
  * This is the whole reason the dedup store can be safe: a call that provably
  * did nothing must stay retryable, while a call whose outcome nobody observed
  * must never be retried blindly. Only one shape means "unknown" — an unsafe
- * HTTP method that was dispatched and never answered.
- *
- * Known limitation: `ECONNREFUSED`/`ENOTFOUND` (nothing ever left the host, so
- * provably not applied) land in the `unknown` bucket too, because the
- * transport-level code sits in `HttpError.details` with no public accessor.
- * The cost is a needless "verify state" answer while a panel is unreachable,
- * bounded by the store's TTL — never a wrong answer. Narrowing it needs a
- * small SDK addition (a `transportCode` getter on `HttpError`), tracked
- * separately.
+ * HTTP method that was dispatched, got no transport code ruling that out,
+ * and never answered. See ADR-0019.
  */
 export function classifyFailure(error: unknown): Applicability {
   // A ZodError, ToolError, ConfigurationError or AuthError never represents a
@@ -34,6 +35,10 @@ export function classifyFailure(error: unknown): Applicability {
 
   // The panel answered, with a 4xx or 5xx: it rejected the request.
   if (error.status !== undefined) return 'not-applied'
+
+  // The connection was refused, or the host never resolved: nothing ever
+  // left the client, whatever method it would have used.
+  if (error.transportCode !== undefined && NEVER_DISPATCHED_CODES.has(error.transportCode)) return 'not-applied'
 
   // No method at all means the failure happened before a request was built.
   const method = error.method

--- a/packages/sdk/src/core/errors/categories/http.error.ts
+++ b/packages/sdk/src/core/errors/categories/http.error.ts
@@ -46,4 +46,10 @@ export class HttpError extends SdkError {
     const value = property(property(this.details, 'config'), 'url')
     return typeof value === 'string' ? value : undefined
   }
+
+  /** Transport-level error code of the failed request (`ECONNREFUSED`, `ETIMEDOUT`, `ERR_CANCELED`, …). `undefined` when the failure carried no such code. */
+  get transportCode(): string | undefined {
+    const value = property(this.details, 'code')
+    return typeof value === 'string' ? value : undefined
+  }
 }

--- a/packages/sdk/src/core/errors/errors.test.ts
+++ b/packages/sdk/src/core/errors/errors.test.ts
@@ -246,6 +246,28 @@ describe('HttpError', () => {
       expect(err.method).toBeUndefined()
     })
   })
+
+  describe('transportCode', () => {
+    it('extracts the code from a transport-level failure', () => {
+      const err = new HttpError({ code: 'ECONNREFUSED' })
+      expect(err.transportCode).toBe('ECONNREFUSED')
+    })
+
+    it('is undefined when details has no code', () => {
+      const err = new HttpError({ response: { status: 404 } })
+      expect(err.transportCode).toBeUndefined()
+    })
+
+    it('is undefined when code is not a string', () => {
+      const err = new HttpError({ code: 111 })
+      expect(err.transportCode).toBeUndefined()
+    })
+
+    it('is undefined when constructed with no details at all', () => {
+      const err = new HttpError()
+      expect(err.transportCode).toBeUndefined()
+    })
+  })
 })
 
 describe('WebhookSignatureError', () => {


### PR DESCRIPTION
## Summary
- Add `HttpError.transportCode` getter to `packages/sdk` — exposes the transport-level error code (`ECONNREFUSED`, `ETIMEDOUT`, `ENOTFOUND`, …) so consumers can distinguish "the request never landed" from "an in-flight write timed out" without reaching into `details`.
- `marzban-mcp`'s `classify.ts` now treats `ECONNREFUSED`/`ENOTFOUND`/`EAI_AGAIN` as `not-applied` (the request never left the client), while `ETIMEDOUT` and similar still resolve to `unknown`.
- Updated `packages/mcp/ARCHITECTURE.md` § Known trade-offs to mark the limitation closed (ADR-0019 itself left unedited, per its immutability convention).
- Updated the docs site's error-handling page with the new getter.

## Test plan
- [x] `pnpm --filter marzban-sdk test:coverage` — 100% coverage, new tests for `transportCode` (code present, absent, non-string, no `details`)
- [x] `pnpm --filter marzban-mcp test:coverage` — 100% coverage, new test per added branch in `classify.ts`
- [x] `pnpm --filter marzban-sdk --filter marzban-mcp lint`
- [x] `pnpm --filter marzban-sdk --filter marzban-mcp types:check`

Closes #128